### PR TITLE
Add ability to specify custom headers in constructor

### DIFF
--- a/src/api/appUsers.js
+++ b/src/api/appUsers.js
@@ -1,6 +1,5 @@
 import { BaseApi } from './base';
 import { AppUsersStripeApi } from './appUsersStripe';
-import { http } from '../utils/http';
 
 /**
  * Init API properties
@@ -25,9 +24,7 @@ export class AppUsersApi extends BaseApi {
      */
     init(props) {
         const url = this.getFullURL('init');
-        return this.validateAuthHeaders().then((headers) => {
-            return http('POST', url, props, headers);
-        });
+        return this.request('POST', url, props);
     }
 
     create(userId, props = {}) {
@@ -46,10 +43,9 @@ export class AppUsersApi extends BaseApi {
         const url = this.getFullURL('appusers');
 
         // this endpoint only accepts JWT auth with app scope
-        return this.validateAuthHeaders(['jwt']).then((authHeaders) => {
-            return http('POST', url, payload, authHeaders);
+        return this.request('POST', url, payload, {
+            allowedAuth: ['jwt']
         });
-
     }
 
     /**
@@ -59,9 +55,7 @@ export class AppUsersApi extends BaseApi {
      */
     get(userId) {
         const url = this.getFullURL('appusers', userId);
-        return this.validateAuthHeaders().then((headers) => {
-            return http('GET', url, {}, headers);
-        });
+        return this.request('GET', url, {});
     }
 
     /**
@@ -72,9 +66,7 @@ export class AppUsersApi extends BaseApi {
      */
     update(userId, attributes) {
         const url = this.getFullURL('appusers', userId);
-        return this.validateAuthHeaders().then((headers) => {
-            return http('PUT', url, attributes, headers);
-        });
+        return this.request('PUT', url, attributes);
     }
 
     /**
@@ -86,11 +78,9 @@ export class AppUsersApi extends BaseApi {
      */
     trackEvent(userId, eventName, attributes = {}) {
         const url = this.getFullURL('appusers', userId, 'events');
-        return this.validateAuthHeaders().then((headers) => {
-            return http('POST', url, {
-                name: eventName,
-                appUser: attributes
-            }, headers);
+        return this.request('POST', url, {
+            name: eventName,
+            appUser: attributes
         });
     }
 
@@ -103,11 +93,9 @@ export class AppUsersApi extends BaseApi {
      */
     updatePushToken(userId, deviceId, token) {
         const url = this.getFullURL('appusers', userId, 'pushToken');
-        return this.validateAuthHeaders().then((headers) => {
-            return http('POST', url, {
-                deviceId,
-                token
-            }, headers);
+        return this.request('POST', url, {
+            deviceId,
+            token
         });
     }
 
@@ -119,8 +107,6 @@ export class AppUsersApi extends BaseApi {
     */
     updateDevice(userId, deviceId, attributes) {
         const url = this.getFullURL('appusers', userId, 'devices', deviceId);
-        return this.validateAuthHeaders().then((headers) => {
-            return http('PUT', url, attributes, headers);
-        });
+        return this.request('PUT', url, attributes);
     }
 }

--- a/src/api/appUsers.js
+++ b/src/api/appUsers.js
@@ -55,7 +55,7 @@ export class AppUsersApi extends BaseApi {
      */
     get(userId) {
         const url = this.getFullURL('appusers', userId);
-        return this.request('GET', url, {});
+        return this.request('GET', url);
     }
 
     /**

--- a/src/api/appUsersStripe.js
+++ b/src/api/appUsersStripe.js
@@ -1,5 +1,4 @@
 import { BaseApi } from './base';
-import { http } from '../utils/http';
 
 
 /**
@@ -14,10 +13,10 @@ export class AppUsersStripeApi extends BaseApi {
         }
 
         const url = this.getFullURL('appUsers', userId, 'stripe', 'customer');
-        return this.validateAuthHeaders(['jwt']).then((headers) => {
-            return http('POST', url, {
-                token
-            }, headers);
+        return this.request('POST', url, {
+            token
+        }, {
+            allowedAuth: ['jwt']
         });
     }
 
@@ -38,8 +37,6 @@ export class AppUsersStripeApi extends BaseApi {
             });
         }
 
-        return this.validateAuthHeaders().then((headers) => {
-            return http('POST', url, body, headers);
-        });
+        return this.request('POST', url, body);
     }
 }

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -1,4 +1,5 @@
 import { urljoin } from '../utils/http';
+import { http } from '../utils/http';
 
 /**
  * Authentication credentials - an app token or a JWT must be provided
@@ -12,9 +13,10 @@ import { urljoin } from '../utils/http';
  * @class BaseApi
  */
 export class BaseApi {
-    constructor(serviceUrl, authHeaders) {
+    constructor(serviceUrl, authHeaders, headers) {
         this.serviceUrl = serviceUrl;
         this.authHeaders = authHeaders;
+        this.headers = headers;
 
         // both are allowed unless stated otherwise
         this.allowedAuth = ['jwt', 'appToken'];
@@ -57,6 +59,25 @@ export class BaseApi {
             return Promise.reject(new Error('Must not use an app token for authentication.'));
         }
 
-        return Promise.resolve(this.authHeaders);
+        return Promise.resolve();
+    }
+
+
+    request(method, url, data, {allowedAuth=this.allowedAuth} = {}) {
+        return this.validateAuthHeaders(allowedAuth)
+            .then(() => {
+                return http(method, url, data, this.getHeaders());
+            });
+    }
+
+    /**
+     * Combines authorization headers and custom headers passed in the Smooch constructor
+     * returns {object} - The headers to be sent in HTTP requests
+     */
+    getHeaders() {
+        return {
+            ...this.authHeaders,
+            ...this.headers
+        };
     }
 }

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -76,8 +76,8 @@ export class BaseApi {
      */
     getHeaders() {
         return {
-            ...this.authHeaders,
-            ...this.headers
+            ...this.headers,
+            ...this.authHeaders
         };
     }
 }

--- a/src/api/conversations.js
+++ b/src/api/conversations.js
@@ -1,5 +1,4 @@
 import { BaseApi } from './base';
-import { http } from '../utils/http';
 
 /**
  * @typedef Message
@@ -14,48 +13,42 @@ export class ConversationsApi extends BaseApi {
 
     /**
      * Fetch an app user's conversation
-     * @param  {string} userId - an user id
+     * @param  {string} userId - a user id
      * @return {APIResponse}
      */
     get(userId) {
         const url = this.getFullURL('appUsers', userId, 'conversation');
-        return this.validateAuthHeaders().then((headers) => {
-            return http('GET', url, {}, headers);
-        });
+        return this.request('GET', url, {});
     }
 
     /**
      * Send a message to an app user's conversation
-     * @param  {string} userId - an user id
+     * @param  {string} userId - a user id
      * @param  {Message} message - the message to be sent
      * @return {APIResponse}
      */
     sendMessage(userId, message) {
         const url = this.getFullURL('appUsers', userId, 'conversation', 'messages');
-        return this.validateAuthHeaders().then((headers) => {
-            return http('POST', url, message, headers);
-        });
+        return this.request('POST', url, message);
     }
 
     /**
      * Send an image to an app user's conversation
-     * @param  {string} userId - an user id
+     * @param  {string} userId - a user id
      * @param  {Blob|Readable stream} source - source image
      * @param  {Message} message - the message to be sent
      * @return {APIResponse}
      */
     uploadImage(userId, source, message = {}) {
         const url = this.getFullURL('appUsers', userId, 'conversation', 'images');
-        return this.validateAuthHeaders().then((headers) => {
-            const data = new FormData();
-            data.append('source', source);
+        const data = new FormData();
+        data.append('source', source);
 
-            Object.keys(message).forEach((key) => {
-                data.append(key, message[key]);
-            });
-
-            return http('POST', url, data, headers);
+        Object.keys(message).forEach((key) => {
+            data.append(key, message[key]);
         });
+
+        return this.request('POST', url, data);
     }
 
     /**
@@ -64,8 +57,6 @@ export class ConversationsApi extends BaseApi {
      */
     resetUnreadCount(userId) {
         const url = this.getFullURL('appUsers', userId, 'conversation', 'read');
-        return this.validateAuthHeaders().then((headers) => {
-            return http('POST', url, {}, headers);
-        });
+        return this.request('POST', url, {});
     }
 }

--- a/src/api/conversations.js
+++ b/src/api/conversations.js
@@ -18,7 +18,7 @@ export class ConversationsApi extends BaseApi {
      */
     get(userId) {
         const url = this.getFullURL('appUsers', userId, 'conversation');
-        return this.request('GET', url, {});
+        return this.request('GET', url);
     }
 
     /**
@@ -57,6 +57,6 @@ export class ConversationsApi extends BaseApi {
      */
     resetUnreadCount(userId) {
         const url = this.getFullURL('appUsers', userId, 'conversation', 'read');
-        return this.request('POST', url, {});
+        return this.request('POST', url);
     }
 }

--- a/src/api/stripe.js
+++ b/src/api/stripe.js
@@ -9,9 +9,7 @@ export class StripeApi extends BaseApi {
 
     getAccount() {
         const url = this.getFullURL('stripe', 'account');
-        return this.validateAuthHeaders().then((headers) => {
-            return http('GET', url, {}, headers);
-        });
+        return this.request('GET', url, {});
     }
 
 }

--- a/src/api/stripe.js
+++ b/src/api/stripe.js
@@ -9,7 +9,7 @@ export class StripeApi extends BaseApi {
 
     getAccount() {
         const url = this.getFullURL('stripe', 'account');
-        return this.request('GET', url, {});
+        return this.request('GET', url);
     }
 
 }

--- a/src/api/webhooks.js
+++ b/src/api/webhooks.js
@@ -1,5 +1,4 @@
 import { BaseApi } from './base';
-import { http } from '../utils/http';
 
 /**
  * Webhook properties
@@ -42,9 +41,7 @@ export class WebhooksApi extends BaseApi {
      */
     list() {
         const url = this.getFullURL('webhooks');
-        return this.validateAuthHeaders().then((authHeaders) => {
-            return http('GET', url, {}, authHeaders);
-        });
+        return this.request('GET', url, {});
     }
 
     /**
@@ -54,10 +51,8 @@ export class WebhooksApi extends BaseApi {
      */
     create(props) {
         const url = this.getFullURL('webhooks');
-        return this.validateAuthHeaders().then((authHeaders) => {
-            return this.validateProps(props, true).then((validatedProps) => {
-                return http('POST', url, validatedProps, authHeaders);
-            });
+        return this.validateProps(props, true).then((validatedProps) => {
+            return this.request('POST', url, validatedProps);
         });
     }
 
@@ -68,9 +63,7 @@ export class WebhooksApi extends BaseApi {
      */
     get(webhookId) {
         const url = this.getFullURL('webhooks', webhookId);
-        return this.validateAuthHeaders().then((authHeaders) => {
-            return http('GET', url, {}, authHeaders);
-        });
+        return this.request('GET', url, {});
     }
 
     /**
@@ -81,10 +74,8 @@ export class WebhooksApi extends BaseApi {
      */
     update(webhookId, props) {
         const url = this.getFullURL('webhooks', webhookId);
-        return this.validateAuthHeaders().then((authHeaders) => {
-            return this.validateProps(props).then(() => {
-                return http('PUT', url, props, authHeaders);
-            });
+        return this.validateProps(props).then((validatedProps) => {
+            return this.request('PUT', url, validatedProps);
         });
     }
 
@@ -96,8 +87,6 @@ export class WebhooksApi extends BaseApi {
      */
     delete(webhookId) {
         const url = this.getFullURL('webhooks', webhookId);
-        return this.validateAuthHeaders().then((authHeaders) => {
-            return http('DELETE', url, undefined, authHeaders);
-        });
+        return this.request('DELETE', url);
     }
 }

--- a/src/api/webhooks.js
+++ b/src/api/webhooks.js
@@ -41,7 +41,7 @@ export class WebhooksApi extends BaseApi {
      */
     list() {
         const url = this.getFullURL('webhooks');
-        return this.request('GET', url, {});
+        return this.request('GET', url);
     }
 
     /**
@@ -63,7 +63,7 @@ export class WebhooksApi extends BaseApi {
      */
     get(webhookId) {
         const url = this.getFullURL('webhooks', webhookId);
-        return this.request('GET', url, {});
+        return this.request('GET', url);
     }
 
     /**

--- a/src/smooch-node.js
+++ b/src/smooch-node.js
@@ -3,7 +3,7 @@ import { WebhooksApi } from './api/webhooks';
 import * as jwt from './utils/jwt';
 
 export class Smooch extends SmoochBase {
-    constructor(auth = {}, serviceUrl) {
+    constructor(auth = {}, options = {}) {
         if (auth.keyId && auth.secret && auth.scope) {
             const jwtBody = {
                 scope: auth.scope
@@ -18,9 +18,9 @@ export class Smooch extends SmoochBase {
             };
         }
 
-        super(auth, serviceUrl);
+        super(auth, options);
 
-        this.webhooks = new WebhooksApi(this.serviceUrl, this.authHeaders);
+        this.webhooks = new WebhooksApi(this.serviceUrl, this.authHeaders, this.headers);
 
         Object.assign(this.utils, {
             jwt

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -7,7 +7,8 @@ import packageInfo from '../package.json';
 export const SERVICE_URL = 'https://api.smooch.io/v1';
 
 export class Smooch {
-    constructor(auth = {}, serviceUrl = SERVICE_URL) {
+    constructor(auth = {}, options = {}) {
+        const {serviceUrl = SERVICE_URL, headers = {}} = options;
         this.VERSION = packageInfo.version;
         this.serviceUrl = serviceUrl;
 
@@ -15,12 +16,12 @@ export class Smooch {
             throw new Error('Key Id or Secret should not be used on the browser side. You must generate a JWT beforehand.');
         }
 
+        this.headers = headers;
         this.authHeaders = getAuthenticationHeaders(auth);
 
-
-        this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders);
-        this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders);
-        this.stripe = new StripeApi(this.serviceUrl, this.authHeaders);
+        this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers);
+        this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders, this.headers);
+        this.stripe = new StripeApi(this.serviceUrl, this.authHeaders, this.headers);
 
         this.utils = {};
     }

--- a/tests/specs/api/appUsers.spec.js
+++ b/tests/specs/api/appUsers.spec.js
@@ -31,7 +31,7 @@ describe('AppUsers API', () => {
             return api.get(userId).then(() => {
                 const fullUrl = api.getFullURL('appusers', userId);
 
-                httpSpy.should.have.been.calledWith('GET', fullUrl, {}, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
     });

--- a/tests/specs/api/appUsers.spec.js
+++ b/tests/specs/api/appUsers.spec.js
@@ -3,7 +3,6 @@ import { getAuthenticationHeaders } from '../../../src/utils/auth';
 import { AppUsersApi } from '../../../src/api/appUsers';
 
 
-
 describe('AppUsers API', () => {
     const serviceUrl = 'http://some-url.com';
     const userId = 'user-id';

--- a/tests/specs/api/base.spec.js
+++ b/tests/specs/api/base.spec.js
@@ -24,6 +24,21 @@ describe('Base API', () => {
         });
     });
 
+    describe('#getHeaders', function() {
+        it('should include auth headers and custom headers', () => {
+            const api = new BaseApi(serviceUrl, {
+                Authorization: 'Bearer stuff'
+            }, {
+                customHeader: '1234'
+            });
+
+            api.getHeaders().should.eql({
+                Authorization: 'Bearer stuff',
+                customHeader: '1234'
+            });
+        });
+    });
+
     describe('#validateAuthHeaders', () => {
         it('should not return an error if Authorization header is present and allowed', () => {
             const api = new BaseApi(serviceUrl, {

--- a/tests/specs/api/conversations.spec.js
+++ b/tests/specs/api/conversations.spec.js
@@ -26,7 +26,7 @@ describe('Conversations API', () => {
         it('should call http', () => {
             return api.get(userId).then(() => {
                 const fullUrl = api.getFullURL('appUsers', userId, 'conversation');
-                httpSpy.should.have.been.calledWith('GET', fullUrl, {}, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
     });
@@ -65,7 +65,7 @@ describe('Conversations API', () => {
         it('should call http', () => {
             return api.resetUnreadCount(userId).then(() => {
                 const fullUrl = api.getFullURL('appUsers', userId, 'conversation', 'read');
-                httpSpy.should.have.been.calledWith('POST', fullUrl, {}, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', fullUrl, undefined, httpHeaders);
             });
         });
     });

--- a/tests/specs/api/conversations.spec.js
+++ b/tests/specs/api/conversations.spec.js
@@ -56,7 +56,7 @@ describe('Conversations API', () => {
                 httpSpy.args[0][0].should.eq('POST');
                 httpSpy.args[0][1].should.eq(fullUrl);
                 httpSpy.args[0][2].should.be.instanceof(FormData);
-                httpSpy.args[0][3].should.eq(httpHeaders);
+                httpSpy.args[0][3].should.eql(httpHeaders);
             });
         });
     });

--- a/tests/specs/api/stripe.spec.js
+++ b/tests/specs/api/stripe.spec.js
@@ -24,7 +24,7 @@ describe('Stripe API', () => {
         it('should call http', () => {
             return api.getAccount().then(() => {
                 const fullUrl = api.getFullURL('stripe', 'account');
-                httpSpy.should.have.been.calledWith('GET', fullUrl, {}, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
 
@@ -37,7 +37,7 @@ describe('Stripe API', () => {
             return api.getAccount()
                 .then(() => {
                     const fullUrl = api.getFullURL('stripe', 'account');
-                    httpSpy.should.have.been.calledWith('GET', fullUrl, {}, httpHeaders);
+                    httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
                 });
         });
 

--- a/tests/specs/api/webhooks.spec.js
+++ b/tests/specs/api/webhooks.spec.js
@@ -68,7 +68,7 @@ describe('Webhooks API', () => {
         it('should call http', () => {
             return api.list().then(() => {
                 const fullUrl = api.getFullURL('webhooks');
-                httpSpy.should.have.been.calledWith('GET', fullUrl, {}, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
 
@@ -88,7 +88,7 @@ describe('Webhooks API', () => {
         it('should call http', () => {
             return api.get(webhookId).then(() => {
                 const fullUrl = api.getFullURL('webhooks', webhookId);
-                httpSpy.should.have.been.calledWith('GET', fullUrl, {}, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
 

--- a/tests/specs/wrappers/node.spec.js
+++ b/tests/specs/wrappers/node.spec.js
@@ -29,6 +29,22 @@ describe('Smooch', () => {
         var smooch = new Smooch(authOptions);
         smooch.authHeaders.should.deep.equal(headers);
     });
+
+    it('should accept custom headers', () => {
+        const authOptions = {
+            jwt: 'jwt'
+        };
+
+        const customHeaders = {
+            myheader: '1234'
+        };
+
+        var smooch = new Smooch(authOptions, {
+            headers: customHeaders
+        });
+        smooch.headers.should.deep.equal(customHeaders);
+    });
+
     describe('generating jwt', () => {
         const keyId = 'keyId';
         const secret = 'secret';


### PR DESCRIPTION
@lemieux @dannytranlx @mspensieri 

We can now pass in custom HTTP headers in the constructor by doing
```js
new Smooch(..., {
    headers: {
        myCustomHeader: '...'
    }
});
```

To pass in the service url, it becomes:
```js
new Smooch(..., {
    serviceUrl: '...'
    headers: {
        myCustomHeader: '...'
    }
});
```