### PR TITLE
Update babel dependencies, move some to peer

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 5.0.0
+    version: 6.2.0
 
 test:
   override:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jsonwebtoken": "5.4.1"
   },
   "peerDependencies": {
-      "babel-runtime": "6.9.0"
+      "babel-runtime": "6.9.x"
   },
   "release-script": {
     "bowerRepo": "git@github.com:smooch/smooch-core-js-bower.git"

--- a/package.json
+++ b/package.json
@@ -21,14 +21,15 @@
     "url": "git@github.com:smooch/smooch-core-js.git"
   },
   "devDependencies": {
-    "babel": "6.1.18",
-    "babel-cli": "6.1.18",
-    "babel-core": "6.1.19",
-    "babel-eslint": "5.0.0",
-    "babel-plugin-transform-runtime": "6.1.18",
-    "babel-preset-es2015": "6.1.18",
+    "babel": "6.5.2",
+    "babel-cli": "6.9.0",
+    "babel-core": "6.9.0",
+    "babel-eslint": "6.0.4",
+    "babel-plugin-transform-runtime": "6.9.0",
+    "babel-preset-es2015": "6.9.0",
     "babel-preset-es2015-loose": "7.0.0",
-    "babel-preset-stage-2": "6.1.18",
+    "babel-preset-stage-2": "6.5.0",
+    "babel-runtime": "6.9.0",
     "browserify": "12.0.1",
     "chai": "3.4.1",
     "esformatter": "0.9.2",
@@ -48,10 +49,12 @@
     "uglifyjs": "2.4.10"
   },
   "dependencies": {
-    "babel-runtime": "6.1.18",
     "form-data": "0.2.0",
     "isomorphic-fetch": "2.2.0",
     "jsonwebtoken": "5.4.1"
+  },
+  "peerDependencies": {
+      "babel-runtime": "6.9.0"
   },
   "release-script": {
     "bowerRepo": "git@github.com:smooch/smooch-core-js-bower.git"


### PR DESCRIPTION
Babel-core was not playing nice with webpack in smooch-js and I ended up updating the babel dependencies everywhere. Also, since I needed to upgrade babel-runtime in smooch-js, smooch-core was adding it's own version. I made it a peer dependency too, so any project using it could provide its own.

@alavers @dannytranlx @Mario54 