### PR TITLE
Remove babel-runtime dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,8 +2,5 @@
   "presets": [
     "stage-2",
     "es2015-loose"
-  ],
-  "plugins": [
-    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -25,11 +25,9 @@
     "babel-cli": "6.9.0",
     "babel-core": "6.9.0",
     "babel-eslint": "6.0.4",
-    "babel-plugin-transform-runtime": "6.9.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-es2015-loose": "7.0.0",
     "babel-preset-stage-2": "6.5.0",
-    "babel-runtime": "6.9.0",
     "browserify": "12.0.1",
     "chai": "3.4.1",
     "esformatter": "0.9.2",
@@ -52,9 +50,6 @@
     "form-data": "0.2.0",
     "isomorphic-fetch": "2.2.0",
     "jsonwebtoken": "5.4.1"
-  },
-  "peerDependencies": {
-    "babel-runtime": "6.9.x"
   },
   "release-script": {
     "bowerRepo": "git@github.com:smooch/smooch-core-js-bower.git"


### PR DESCRIPTION
`babel-plugin-transform-runtime` job is to externalize all references to helpers and make them point to an external `babel-runtime` package. By removing it, babel will embed those helpers in each files. It makes a bigger transpiled file, but avoid having a useless peer dependency for most of people.

@alavers 