### PR TITLE
Improve error message for node env

### DIFF
--- a/src/smooch-node.js
+++ b/src/smooch-node.js
@@ -14,7 +14,7 @@ export class Smooch extends SmoochBase {
                 throw new Error('Invalid auth: missing keyId.');
             }
 
-            if (!auth.keyId) {
+            if (!auth.secret) {
                 throw new Error('Invalid auth: missing secret.');
             }
         }

--- a/src/smooch-node.js
+++ b/src/smooch-node.js
@@ -5,6 +5,20 @@ import * as jwt from './utils/jwt';
 
 export class Smooch extends SmoochBase {
     constructor(auth = {}, options = {}) {
+        if (auth.keyId || auth.secret) {
+            if (!auth.scope) {
+                throw new Error('Invalid auth: missing scope.');
+            }
+
+            if (!auth.keyId) {
+                throw new Error('Invalid auth: missing keyId.');
+            }
+
+            if (!auth.keyId) {
+                throw new Error('Invalid auth: missing secret.');
+            }
+        }
+
         if (auth.keyId && auth.secret && auth.scope) {
             const jwtBody = {
                 scope: auth.scope


### PR DESCRIPTION
When using `keyId` and `secret` without a `scope`, the whole auth object was just passed to the `super` constructor (which is the one used in the browser) and it was throwing an error about not being able to use `keyId` and `secret` in the browser (while on Node)... so this was misleading.

This PR adds more checks to avoid that situation.

@mspensieri @dannytranlx @hebime 