### PR TITLE
Extract a scope from all incoming credential types

### DIFF
--- a/src/api/webhooks.js
+++ b/src/api/webhooks.js
@@ -87,7 +87,6 @@ export class WebhooksApi extends BaseApi {
      * Deletes a webhook
      * @param  {string} webhookId - an id
      * @return {APIResponse}
-     import { getAuthenticationHeaders } from '../../../src/utils/auth';
      */
     delete(webhookId) {
         const url = this.getFullURL('webhooks', webhookId);

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -11,6 +11,7 @@ export class Smooch {
         const {serviceUrl = SERVICE_URL, headers = {}} = options;
         this.VERSION = packageInfo.version;
         this.serviceUrl = serviceUrl;
+        this.scope = 'appUser';
 
         if (auth.keyId || auth.secret) {
             throw new Error('Key Id or Secret should not be used on the browser side. You must generate a JWT beforehand.');

--- a/tests/mocks/jwt.js
+++ b/tests/mocks/jwt.js
@@ -1,0 +1,11 @@
+const jwt = require('jsonwebtoken');
+
+export function testJwt() {
+    return jwt.sign({
+        scope: 'appUser'
+    }, 'secret', {
+        headers: {
+            kid: 'keyid'
+        }
+    });
+}

--- a/tests/mocks/jwt.js
+++ b/tests/mocks/jwt.js
@@ -1,8 +1,8 @@
-const jwt = require('jsonwebtoken');
+import { sign } from 'jsonwebtoken';
 
-export function testJwt() {
-    return jwt.sign({
-        scope: 'appUser'
+export function testJwt(scope = 'appUser') {
+    return sign({
+        scope
     }, 'secret', {
         headers: {
             kid: 'keyid'

--- a/tests/specs/api/appUsers.spec.js
+++ b/tests/specs/api/appUsers.spec.js
@@ -2,6 +2,7 @@ import * as httpMock from '../../mocks/http';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
 import { AppUsersApi } from '../../../src/api/appUsers';
 import { createReadStream } from 'streamifier';
+import { testJwt } from '../../mocks/jwt';
 
 describe('AppUsers API', () => {
     const serviceUrl = 'http://some-url.com';
@@ -74,7 +75,7 @@ describe('AppUsers API', () => {
         };
 
         const jwtHttpHeaders = getAuthenticationHeaders({
-            jwt: 'jwt'
+            jwt: testJwt()
         });
 
         it('should throw an error if used with app token', (done) => {

--- a/tests/specs/api/appUsersStripe.spec.js
+++ b/tests/specs/api/appUsersStripe.spec.js
@@ -1,13 +1,13 @@
 import * as httpMock from '../../mocks/http';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
 import { AppUsersStripeApi } from '../../../src/api/appUsersStripe';
-
+import { testJwt } from '../../mocks/jwt';
 
 describe('AppUsersStripe API', () => {
     const serviceUrl = 'http://some-url.com';
     const userId = 'user-id';
     const httpHeaders = getAuthenticationHeaders({
-        jwt: 'jwt'
+        jwt: testJwt()
     });
     let httpSpy;
     let api;

--- a/tests/specs/api/appUsersViber.spec.js
+++ b/tests/specs/api/appUsersViber.spec.js
@@ -1,12 +1,13 @@
 import * as httpMock from '../../mocks/http';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
 import { AppUsersViberApi } from '../../../src/api/appUsersViber';
+import { testJwt } from '../../mocks/jwt';
 
 describe('AppUsersViber API', () => {
     const serviceUrl = 'http://some-url.com';
     const userId = 'user-id';
     const httpHeaders = getAuthenticationHeaders({
-        jwt: 'jwt'
+        jwt: testJwt()
     });
     let httpSpy;
     let api;

--- a/tests/specs/api/appUsersWeChat.spec.js
+++ b/tests/specs/api/appUsersWeChat.spec.js
@@ -1,12 +1,13 @@
 import * as httpMock from '../../mocks/http';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
 import { AppUsersWeChatApi } from '../../../src/api/appUsersWeChat';
+import { testJwt } from '../../mocks/jwt';
 
 describe('AppUsersWeChat API', () => {
     const serviceUrl = 'http://some-url.com';
     const userId = 'user-id';
     const httpHeaders = getAuthenticationHeaders({
-        jwt: 'jwt'
+        jwt: testJwt()
     });
     let httpSpy;
     let api;

--- a/tests/specs/api/base.spec.js
+++ b/tests/specs/api/base.spec.js
@@ -1,8 +1,9 @@
 import { BaseApi } from '../../../src/api/base';
+import { testJwt } from '../../mocks/jwt';
 
 const serviceUrl = 'http://some-url.com';
 const headers = {
-    jwt: 'jwt'
+    jwt: testJwt()
 };
 
 describe('Base API', () => {

--- a/tests/specs/api/menu.spec.js
+++ b/tests/specs/api/menu.spec.js
@@ -1,7 +1,7 @@
 import * as httpMock from '../../mocks/http';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
 import { MenuApi } from '../../../src/api/menu';
-
+import { testJwt } from '../../mocks/jwt';
 
 describe('Menu API', () => {
     const serviceUrl = 'http://some-url.com';
@@ -9,7 +9,7 @@ describe('Menu API', () => {
     const noPropsMessage = 'Must provide props.';
     const noItemsMessage = 'Must provide an array of items.';
     const httpHeaders = getAuthenticationHeaders({
-        jwt: 'jwt'
+        jwt: testJwt()
     });
     let httpSpy;
     let api;

--- a/tests/specs/api/stripe.spec.js
+++ b/tests/specs/api/stripe.spec.js
@@ -1,11 +1,12 @@
 import * as httpMock from '../../mocks/http';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
 import { StripeApi } from '../../../src/api/stripe';
+import { testJwt } from '../../mocks/jwt';
 
 describe('Stripe API', () => {
     const serviceUrl = 'http://some-url.com';
     const httpHeaders = getAuthenticationHeaders({
-        jwt: 'jwt'
+        jwt: testJwt()
     });
     let httpSpy;
     let api;

--- a/tests/specs/api/webhooks.spec.js
+++ b/tests/specs/api/webhooks.spec.js
@@ -1,7 +1,7 @@
 import * as httpMock from '../../mocks/http';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
 import { WebhooksApi } from '../../../src/api/webhooks';
-
+import { testJwt } from '../../mocks/jwt';
 
 describe('Webhooks API', () => {
     const serviceUrl = 'http://some-url.com';
@@ -13,7 +13,7 @@ describe('Webhooks API', () => {
     const noPropsMessage = 'Must provide props.';
     const noTargetMessage = 'Must provide a target.';
     const httpHeaders = getAuthenticationHeaders({
-        jwt: 'jwt'
+        jwt: testJwt()
     });
     let httpSpy;
     let api;

--- a/tests/specs/utils/auth.spec.js
+++ b/tests/specs/utils/auth.spec.js
@@ -1,4 +1,5 @@
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
+import { testJwt } from '../../mocks/jwt';
 
 describe('Auth utils', () => {
     describe('#getAuthenticationHeaders', () => {
@@ -13,7 +14,7 @@ describe('Auth utils', () => {
 
         it('should transform a JWT', () => {
             const baseHeaders = {
-                jwt: 'jwt'
+                jwt: testJwt()
             };
 
             const headers = getAuthenticationHeaders(baseHeaders);
@@ -35,7 +36,7 @@ describe('Auth utils', () => {
 
         it('should use the JWT if both are provided', () => {
             const baseHeaders = {
-                jwt: 'jwt',
+                jwt: testJwt(),
                 appToken: 'app-token'
             };
 

--- a/tests/specs/utils/http.spec.js
+++ b/tests/specs/utils/http.spec.js
@@ -114,8 +114,12 @@ describe('HTTP', () => {
             });
         });
 
+        function randomIntBetween(min, max) {
+            return Math.floor(Math.random() * (max - min)) + min;
+        }
+
         describe('#handleStatus', () => {
-            for (let status = 200; status < 300; status++) {
+            [200, randomIntBetween(201, 299), 299].forEach((status) => {
                 it('should not throw an error with HTTP ' + status, () => {
                     const response = handleStatus({
                         status: status
@@ -123,9 +127,9 @@ describe('HTTP', () => {
 
                     response.status.should.equals(status);
                 });
-            }
+            });
 
-            for (let status = 300; status < 600; status++) {
+            [300, randomIntBetween(301, 599), 599].forEach((status) => {
                 it('should throw an error with HTTP ' + status, () => {
                     const response = {
                         status: status,
@@ -140,40 +144,39 @@ describe('HTTP', () => {
                         e.response.should.equal(response);
                     }
                 });
-            }
+
+            });
         });
 
         describe('#handleBody', () => {
-            const noBodyStatuses = [202, 204];
-            for (let status = 200; status < 300; status++) {
-                if (noBodyStatuses.indexOf(status) >= 0) {
-                    it('should not return a body if HTTP ' + status, () => {
-                        return handleBody({
-                            status: status,
-                            headers: getMockedHeaders({
-                                'Content-Type': 'application/json'
-                            })
-                        }).then((body) => {
-                            expect(body).to.be.undefined;
-                        });
+            [202, 204].forEach((status) => {
+                it('should not return a body if HTTP ' + status, () => {
+                    return handleBody({
+                        status: status,
+                        headers: getMockedHeaders({
+                            'Content-Type': 'application/json'
+                        })
+                    }).then((body) => {
+                        expect(body).to.be.undefined;
                     });
-                } else {
-                    it('should return the value of json() if HTTP ' + status, () => {
-                        const response = {
-                            status: status,
-                            headers: getMockedHeaders({
-                                'Content-Type': 'application/json'
-                            }),
-                            json: sinon.spy(() => 'body for http ' + status)
-                        };
+                });
+            });
+            [200, 201, 203, randomIntBetween(205, 299), 299].forEach((status) => {
+                it('should return the value of json() if HTTP ' + status, () => {
+                    const response = {
+                        status: status,
+                        headers: getMockedHeaders({
+                            'Content-Type': 'application/json'
+                        }),
+                        json: sinon.spy(() => 'body for http ' + status)
+                    };
 
-                        const body = handleBody(response);
+                    const body = handleBody(response);
 
-                        response.json.should.have.been.calledOnce;
-                        body.should.equals(response.json());
-                    });
-                }
-            }
+                    response.json.should.have.been.calledOnce;
+                    body.should.equals(response.json());
+                });
+            });
 
             it('should not return a body if content type is not application/json', () => {
                 return handleBody({

--- a/tests/specs/utils/http.spec.js
+++ b/tests/specs/utils/http.spec.js
@@ -114,12 +114,8 @@ describe('HTTP', () => {
             });
         });
 
-        function randomIntBetween(min, max) {
-            return Math.floor(Math.random() * (max - min)) + min;
-        }
-
         describe('#handleStatus', () => {
-            [200, randomIntBetween(201, 299), 299].forEach((status) => {
+            [200, 201, 202, 203, 204, 299].forEach((status) => {
                 it('should not throw an error with HTTP ' + status, () => {
                     const response = handleStatus({
                         status: status
@@ -129,7 +125,7 @@ describe('HTTP', () => {
                 });
             });
 
-            [300, randomIntBetween(301, 599), 599].forEach((status) => {
+            [300, 301, 302, 303, 304, 401, 402, 403, 404, 429, 500, 503, 599].forEach((status) => {
                 it('should throw an error with HTTP ' + status, () => {
                     const response = {
                         status: status,
@@ -161,7 +157,7 @@ describe('HTTP', () => {
                     });
                 });
             });
-            [200, 201, 203, randomIntBetween(205, 299), 299].forEach((status) => {
+            [200, 201, 203, 299].forEach((status) => {
                 it('should return the value of json() if HTTP ' + status, () => {
                     const response = {
                         status: status,

--- a/tests/specs/wrappers/browser.spec.js
+++ b/tests/specs/wrappers/browser.spec.js
@@ -1,15 +1,16 @@
 import Smooch from '../../../src/wrappers/browser';
+
 describe('Smooch', () => {
     it('should not have the webhooks API', () => {
         const smooch = new Smooch({
-            jwt: 'jwt'
+            jwt: 'jwt_nodecoding'
         });
         expect(smooch.webhooks).to.be.undefined;
     });
 
     it('should not have the JWT utils', () => {
         const smooch = new Smooch({
-            jwt: 'jwt'
+            jwt: 'jwt_nodecoding'
         });
         expect(smooch.utils.jwt).to.be.undefined;
     });

--- a/tests/specs/wrappers/browser.spec.js
+++ b/tests/specs/wrappers/browser.spec.js
@@ -36,4 +36,9 @@ describe('Smooch', () => {
             e.message.should.contain('beforehand');
         }
     });
+
+    it('should force appUser scope', () => {
+        const s = new Smooch({appToken:'foo', scope: 'appMaker'});
+        s.should.have.property('scope', 'appUser');
+    });
 });

--- a/tests/specs/wrappers/node.spec.js
+++ b/tests/specs/wrappers/node.spec.js
@@ -1,28 +1,27 @@
 import jwt from 'jsonwebtoken';
-
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
-
 import Smooch from '../../../src/wrappers/node';
+import { testJwt } from '../../mocks/jwt';
 
 describe('Smooch', () => {
 
     it('should have the webhooks API', () => {
         var smooch = new Smooch({
-            jwt: 'jwt'
+            jwt: testJwt()
         });
         smooch.webhooks.should.exist;
     });
 
     it('should have the JWT utils', () => {
         var smooch = new Smooch({
-            jwt: 'jwt'
+            jwt: testJwt()
         });
         smooch.utils.jwt.should.exist;
     });
 
     it('should generate the auth headers', () => {
         const authOptions = {
-            jwt: 'jwt'
+            jwt: testJwt()
         };
         const headers = getAuthenticationHeaders(authOptions);
 
@@ -32,7 +31,7 @@ describe('Smooch', () => {
 
     it('should accept custom headers', () => {
         const authOptions = {
-            jwt: 'jwt'
+            jwt: testJwt()
         };
 
         const customHeaders = {


### PR DESCRIPTION
In the browser, scope is forced to 'appUser'. In node only, incoming
auth.jwt param will be rejected if its malformed or missing scope.

Take two of https://github.com/smooch/smooch-core-js/pull/53. The scope I'll be using later when adding managed account APIs. I've also cherry picked various  cleanup fixes from the closed PR.