### PR TITLE
Accept either single objects or arg lists in API methods

### DIFF
--- a/src/api/appUsers.js
+++ b/src/api/appUsers.js
@@ -2,6 +2,7 @@ import { BaseApi } from './base';
 import { AppUsersStripeApi } from './appUsersStripe';
 import { AppUsersViberApi } from './appUsersViber';
 import { AppUsersWeChatApi } from './appUsersWeChat';
+import smoochMethod from '../utils/smoochMethod';
 
 /**
  * Init API properties
@@ -9,7 +10,8 @@ import { AppUsersWeChatApi } from './appUsersWeChat';
  */
 
 /**
- * @class AppUsersApi
+ * @constructor
+ * @name AppUsersApi
  * @extends BaseApi
  */
 export class AppUsersApi extends BaseApi {
@@ -20,192 +22,262 @@ export class AppUsersApi extends BaseApi {
         this.viber = new AppUsersViberApi(...args);
         this.wechat = new AppUsersWeChatApi(...args);
     }
+}
 
+Object.assign(AppUsersApi.prototype, {
     /**
      * Initializes the conversation for a user
+     * @memberof AppUsersApi.prototype
+     * @method init
      * @param  {InitProps} props
      * @return {APIResponse}
      */
-    init(props) {
-        const url = this.getFullURL('init');
-        return this.request('POST', url, props);
-    }
-
-    create(userId, props = {}) {
-        if (!userId || !userId.trim()) {
-            return Promise.reject(new Error('Must provide a userId.'));
+    init: smoochMethod({
+        params: ['props'],
+        func: function init(props) {
+            const url = this.getFullURL('init');
+            return this.request('POST', url, props);
         }
+    }),
 
-        const payload = Object.assign({
-            userId: userId
-        }, props);
+    /**
+     * Create
+     * @memberof AppUsersApi.prototype
+     * @method create
+     * @param  {string} userId
+     * @param  {object=} props
+     * @return {APIResponse}
+     */
+    create: smoochMethod({
+        params: ['userId', 'props'],
+        optional: ['props'],
+        func: function create(userId, props = {}) {
+            if (!userId || !userId.trim()) {
+                return Promise.reject(new Error('Must provide a userId.'));
+            }
 
-        if (props.signedUpAt && !(props.signedUpAt instanceof Date)) {
-            return Promise.reject(new Error('signedUpAt must be a date.'));
+            const payload = Object.assign({
+                userId: userId
+            }, props);
+
+            if (props.signedUpAt && !(props.signedUpAt instanceof Date)) {
+                return Promise.reject(new Error('signedUpAt must be a date.'));
+            }
+
+            const url = this.getFullURL('appusers');
+
+            // this endpoint only accepts JWT auth with app scope
+            return this.request('POST', url, payload, {
+                allowedAuth: ['jwt']
+            });
         }
-
-        const url = this.getFullURL('appusers');
-
-        // this endpoint only accepts JWT auth with app scope
-        return this.request('POST', url, payload, {
-            allowedAuth: ['jwt']
-        });
-    }
+    }),
 
     /**
      * Fetch an app user
+     * @memberof AppUsersApi.prototype
+     * @method get
      * @param  {string} userId - a user id
      * @return {APIResponse}
      */
-    get(userId) {
-        const url = this.getFullURL('appusers', userId);
-        return this.request('GET', url);
-    }
+    get: smoochMethod({
+        params: ['userId'],
+        func: function get(userId) {
+            const url = this.getFullURL('appusers', userId);
+            return this.request('GET', url);
+        }
+    }),
 
     /**
      * Update an app user
-     * @param  {string} userId     - a user id
-     * @param  {object} attributes - the attributes to update
+     * @memberof AppUsersApi.prototype
+     * @method update
+     * @param  {string} userId - a user id
+     * @param  {object} props  - the props to update
      * @return {APIResponse}
      */
-    update(userId, attributes) {
-        const url = this.getFullURL('appusers', userId);
-        return this.request('PUT', url, attributes);
-    }
+    update: smoochMethod({
+        params: ['userId', 'props'],
+        func: function update(userId, props) {
+            const url = this.getFullURL('appusers', userId);
+            return this.request('PUT', url, props);
+        }
+    }),
 
     /**
      * Track an event for an app user
-     * @param  {string} userId     - a user id
-     * @param  {string} eventName  - the name of the event to track
-     * @param  {object} {attributes} - attributes to update before tracking the event
+     * @memberof AppUsersApi.prototype
+     * @method trackEvent
+     * @param  {string} userId    - a user id
+     * @param  {string} eventName - the name of the event to track
+     * @param  {object=} props    - props to update before tracking the event
      * @return {APIResponse}
      */
-    trackEvent(userId, eventName, attributes = {}) {
-        const url = this.getFullURL('appusers', userId, 'events');
-        return this.request('POST', url, {
-            name: eventName,
-            appUser: attributes
-        });
-    }
+    trackEvent: smoochMethod({
+        params: ['userId', 'eventName', 'props'],
+        optional: ['props'],
+        func: function trackEvent(userId, eventName, props = {}) {
+            const url = this.getFullURL('appusers', userId, 'events');
+            return this.request('POST', url, {
+                name: eventName,
+                appUser: props
+            });
+        }
+    }),
 
     /**
      * Update the push notification token for a given app user's device
-     * @param  {string} userId     - a user id
-     * @param  {string} deviceId  - a device id
-     * @param  {string} token  - a push notification token
+     * @memberof AppUsersApi.prototype
+     * @method updatePushToken
+     * @param  {string} userId   - a user id
+     * @param  {string} deviceId - a device id
+     * @param  {string} token    - a push notification token
      * @return {APIResponse}
      */
-    updatePushToken(userId, deviceId, token) {
-        const url = this.getFullURL('appusers', userId, 'pushToken');
-        return this.request('POST', url, {
-            deviceId,
-            token
-        });
-    }
+    updatePushToken: smoochMethod({
+        params: ['userId', 'deviceId', 'token'],
+        func: function updatePushToken(userId, deviceId, token) {
+            const url = this.getFullURL('appusers', userId, 'pushToken');
+            return this.request('POST', url, {
+                deviceId,
+                token
+            });
+        }
+    }),
 
     /**
     * Update the specified device for a given app user
-    * @param {string} userId    - a user id
-    * @param  {string} deviceId  - a device id
-    * @param  {object} {attributes} - attributes to update on the device
+    * @memberof AppUsersApi.prototype
+    * @method updateDevice
+    * @param  {string} userId   - a user id
+    * @param  {string} deviceId - a device id
+    * @param  {object} props    - props to update on the device
     */
-    updateDevice(userId, deviceId, attributes) {
-        const url = this.getFullURL('appusers', userId, 'devices', deviceId);
-        return this.request('PUT', url, attributes);
-    }
+    updateDevice: smoochMethod({
+        params: ['userId', 'deviceId', 'props'],
+        func: function updateDevice(userId, deviceId, props) {
+            const url = this.getFullURL('appusers', userId, 'devices', deviceId);
+            return this.request('PUT', url, props);
+        }
+    }),
 
     /**
      * Links the specified channel to a user
-     * @param {string} userId - a user id
-     * @param {object} data - the data object
+     * @memberof AppUsersApi.prototype
+     * @method linkChannel
+     * @param  {string} userId - a user id
+     * @param  {object} data   - the data object
      * @return {APIResponse}
      */
-    linkChannel(userId, data) {
-        if (!data.type) {
-            return Promise.reject(new Error('Must provide a channel type.'));
-        }
+    linkChannel: smoochMethod({
+        params: ['userId', 'data'],
+        func: function linkChannel(userId, data) {
+            if (!data.type) {
+                return Promise.reject(new Error('Must provide a channel type.'));
+            }
 
-        const url = this.getFullURL('appUsers', userId, 'channels');
-        return this.request('POST', url, data);
-    }
+            const url = this.getFullURL('appUsers', userId, 'channels');
+            return this.request('POST', url, data);
+        }
+    }),
 
     /**
      * Unlinks the specified channel
-     * @param {string} userId - a user id
-     * @param {string} channel - the channel to unlink
+     * @memberof AppUsersApi.prototype
+     * @method unlinkChannel
+     * @param  {string} userId  - a user id
+     * @param  {string} channel - the channel to unlink
      * @return {APIResponse}
      */
-    unlinkChannel(userId, channel) {
-        const url = this.getFullURL('appUsers', userId, 'channels', channel);
-        return this.request('DELETE', url);
-    }
+    unlinkChannel: smoochMethod({
+        params: ['userId', 'channel'],
+        func: function unlinkChannel(userId, channel) {
+            const url = this.getFullURL('appUsers', userId, 'channels', channel);
+            return this.request('DELETE', url);
+        }
+    }),
 
     /**
      * Pings linked channel
-     * @param {string} userId - a user id
-     * @param {string} channel - the channel to ping
+     * @memberof AppUsersApi.prototype
+     * @method pingChannel
+     * @param  {string} userId  - a user id
+     * @param  {string} channel - the channel to ping
      * @return {APIResponse}
      */
-    pingChannel(userId, channel) {
-        const url = this.getFullURL('appUsers', userId, 'integrations', channel, 'ping');
-        return this.request('POST', url);
-    }
+    pingChannel: smoochMethod({
+        params: ['userId', 'channel'],
+        func: function pingChannel(userId, channel) {
+            const url = this.getFullURL('appUsers', userId, 'integrations', channel, 'ping');
+            return this.request('POST', url);
+        }
+    }),
 
     /**
      * Fetch app user's messages
+     * @memberof AppUsersApi.prototype
+     * @method getMessages
      * @param  {string} userId - a user id
-     * @param  {object} options - the paging parameters (before, after)
+     * @param  {object=} query - paging parameters (before, after)
      * @return {APIResponse}
      */
-    getMessages(userId, {before, after} = {}) {
-        if (before && after) {
-            return Promise.reject(new Error('Parameters "before" and "after" are mutually exclusive. You must provide one or the other.'));
-        }
+    getMessages: smoochMethod({
+        params: ['userId', 'query'],
+        optional: ['query'],
+        func: function getMessages(userId, query = {}) {
+            const {before, after} = query;
+            if (before && after) {
+                return Promise.reject(new Error('Parameters "before" and "after" are mutually exclusive. You must provide one or the other.'));
+            }
 
-        const url = this.getFullURL('appUsers', userId, 'messages');
-
-        let params;
-
-        if (before) {
-            params = {
+            const q = before ? {
                 before
-            };
-        } else if (after) {
-            params = {
+            } : after ? {
                 after
-            };
+            } : undefined;
+            const url = this.getFullURL('appUsers', userId, 'messages');
+            return this.request('GET', url, q);
         }
-
-        return this.request('GET', url, params);
-    }
+    }),
 
     /**
      * Send a message to an app user's conversation
-     * @param  {string} userId - a user id
-     * @param  {Message} message - the message to be sent
-     * @return  {APIResponse}
-     */
-    sendMessage(userId, message) {
-        const url = this.getFullURL('appUsers', userId, 'messages');
-        return this.request('POST', url, message);
-    }
-
-    /**
-     * Send an image to an app user's conversation
-     * @param  {string} userId - a user id
-     * @param  {Blob|Readable stream} source - source image
+     * @memberof AppUsersApi.prototype
+     * @method sendMessage
+     * @param  {string} userId   - a user id
      * @param  {Message} message - the message to be sent
      * @return {APIResponse}
      */
-    uploadImage(userId, source, message = {}) {
-        const url = this.getFullURL('appUsers', userId, 'images');
-        const data = new FormData();
-        data.append('source', source);
+    sendMessage: smoochMethod({
+        params: ['userId', 'message'],
+        func: function sendMessage(userId, message) {
+            const url = this.getFullURL('appUsers', userId, 'messages');
+            return this.request('POST', url, message);
+        }
+    }),
 
-        Object.keys(message).forEach((key) => {
-            data.append(key, message[key]);
-        });
+    /**
+     * Send an image to an app user's conversation
+     * @memberof AppUsersApi.prototype
+     * @method uploadImage
+     * @param  {string} userId   - a user id
+     * @param  {Readable} source - source image readable stream
+     * @param  {Message=} message - the message to be sent
+     * @return {APIResponse}
+     */
+    uploadImage: smoochMethod({
+        params: ['userId', 'source', 'message'],
+        optional: ['message'],
+        func: function uploadImage(userId, source, message = {}) {
+            const url = this.getFullURL('appUsers', userId, 'images');
+            const data = new FormData();
+            data.append('source', source);
 
-        return this.request('POST', url, data);
-    }
-}
+            Object.keys(message).forEach((key) => {
+                data.append(key, message[key]);
+            });
+
+            return this.request('POST', url, data);
+        }
+    })
+});

--- a/src/api/appUsers.js
+++ b/src/api/appUsers.js
@@ -15,7 +15,6 @@ import smoochMethod from '../utils/smoochMethod';
  * @extends BaseApi
  */
 export class AppUsersApi extends BaseApi {
-
     constructor(...args) {
         super(...args);
         this.stripe = new AppUsersStripeApi(...args);

--- a/src/api/appUsersStripe.js
+++ b/src/api/appUsersStripe.js
@@ -1,42 +1,69 @@
 import { BaseApi } from './base';
-
+import smoochMethod from '../utils/smoochMethod';
 
 /**
- * @class AppUsersStripeApi
+ * @constructor
+ * @name AppUsersStripeApi
  * @extends BaseApi
  */
 export class AppUsersStripeApi extends BaseApi {
+}
 
-    updateCustomer(userId, token) {
-        if (!token) {
-            return Promise.reject(new Error('Must provide a Stripe token.'));
-        }
+Object.assign(AppUsersStripeApi.prototype, {
+    /**
+     * Assign a stripe payment method to an existing user
+     * @memberof AppUsersStripeApi.prototype
+     * @method updateCustomer
+     * @param  {string} userId
+     * @param  {string} token
+     * @return {APIResponse}
+     */
+    updateCustomer: smoochMethod({
+        params: ['userId', 'token'],
+        func: function updateCustomer(userId, token) {
+            if (!token) {
+                return Promise.reject(new Error('Must provide a Stripe token.'));
+            }
 
-        const url = this.getFullURL('appUsers', userId, 'stripe', 'customer');
-        return this.request('POST', url, {
-            token
-        }, {
-            allowedAuth: ['jwt']
-        });
-    }
-
-    createTransaction(userId, actionId, token) {
-        if (!actionId) {
-            return Promise.reject(new Error('Must provide an action id.'));
-        }
-
-        const url = this.getFullURL('appUsers', userId, 'stripe', 'transaction');
-
-        const body = {
-            actionId
-        };
-
-        if (token) {
-            Object.assign(body, {
+            const url = this.getFullURL('appUsers', userId, 'stripe', 'customer');
+            return this.request('POST', url, {
                 token
+            }, {
+                allowedAuth: ['jwt']
             });
         }
+    }),
 
-        return this.request('POST', url, body);
-    }
-}
+    /**
+     * Create a one-time stripe transaction
+     * @memberof AppUsersStripeApi.prototype
+     * @method createTransaction
+     * @param  {string} userId
+     * @param  {string} actionId
+     * @param  {string} token
+     * @return {APIResponse}
+     */
+    createTransaction: smoochMethod({
+        params: ['userId', 'actionId', 'token'],
+        optional: ['token'],
+        func: function createTransaction(userId, actionId, token) {
+            if (!actionId) {
+                return Promise.reject(new Error('Must provide an action id.'));
+            }
+
+            const url = this.getFullURL('appUsers', userId, 'stripe', 'transaction');
+
+            const body = {
+                actionId
+            };
+
+            if (token) {
+                Object.assign(body, {
+                    token
+                });
+            }
+
+            return this.request('POST', url, body);
+        }
+    })
+});

--- a/src/api/appUsersViber.js
+++ b/src/api/appUsersViber.js
@@ -1,15 +1,27 @@
 import { BaseApi } from './base';
-
+import smoochMethod from '../utils/smoochMethod';
 
 /**
- * @class AppUsersViberApi
+ * @constructor
+ * @name AppUsersViberApi
  * @extends BaseApi
  */
 export class AppUsersViberApi extends BaseApi {
-
-    getQRCode(userId) {
-        const url = this.getFullURL('appUsers', userId, 'integrations', 'viber', 'qrcode');
-        return this.request('GET', url);
-    }
-
 }
+
+Object.assign(AppUsersViberApi.prototype, {
+    /**
+     * Generage a QR code to link an existing user with Viber
+     * @memberof AppUsersViberApi.prototype
+     * @method getQRCode
+     * @param  {string} userId
+     * @return {APIResponse}
+     */
+    getQRCode: smoochMethod({
+        params: ['userId'],
+        func: function getQRCode(userId) {
+            const url = this.getFullURL('appUsers', userId, 'integrations', 'viber', 'qrcode');
+            return this.request('GET', url);
+        }
+    })
+});

--- a/src/api/appUsersWeChat.js
+++ b/src/api/appUsersWeChat.js
@@ -1,15 +1,27 @@
 import { BaseApi } from './base';
-
+import smoochMethod from '../utils/smoochMethod';
 
 /**
- * @class AppUsersWeChatApi
+ * @constructor
+ * @name AppUsersWeChatApi
  * @extends BaseApi
  */
 export class AppUsersWeChatApi extends BaseApi {
-
-    getQRCode(userId) {
-        const url = this.getFullURL('appUsers', userId, 'integrations', 'wechat', 'qrcode');
-        return this.request('GET', url);
-    }
-
 }
+
+Object.assign(AppUsersWeChatApi.prototype, {
+    /**
+     * Generage a QR code to link an existing user with WeChat
+     * @memberof AppUsersViberApi.prototype
+     * @method getQRCode
+     * @param  {string} userId
+     * @return {APIResponse}
+     */
+    getQRCode: smoochMethod({
+        params: ['userId'],
+        func: function getQRCode(userId) {
+            const url = this.getFullURL('appUsers', userId, 'integrations', 'wechat', 'qrcode');
+            return this.request('GET', url);
+        }
+    })
+});

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -32,6 +32,12 @@ export class BaseApi {
         return urljoin(this.serviceUrl, ...fragments);
     }
 
+    /**
+     * Build an URL from fragments to call the API
+     * Automatically append /apps/ if required, and remove appId fragment if
+     * it is undefined if not required
+     * @return {string} - an URL
+     */
     getFullURLWithApp(...args) {
         if (this.requireAppId) {
             args.unshift('apps');

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -13,10 +13,11 @@ import { http } from '../utils/http';
  * @class BaseApi
  */
 export class BaseApi {
-    constructor(serviceUrl, authHeaders, headers) {
+    constructor(serviceUrl, authHeaders, headers, requireAppId) {
         this.serviceUrl = serviceUrl;
         this.authHeaders = authHeaders;
         this.headers = headers;
+        this.requireAppId = !!requireAppId;
 
         // both are allowed unless stated otherwise
         this.allowedAuth = ['jwt', 'appToken'];
@@ -27,8 +28,17 @@ export class BaseApi {
      * @return {string} - an URL
      */
     getFullURL(...args) {
-        const fragments = args.map((fragment) => encodeURIComponent(fragment));
+        const fragments = args.map((a) => encodeURIComponent(a));
         return urljoin(this.serviceUrl, ...fragments);
+    }
+
+    getFullURLWithApp(...args) {
+        if (this.requireAppId) {
+            args.unshift('apps');
+        } else {
+            args = args.filter((a) => a !== undefined);
+        }
+        return this.getFullURL(...args);
     }
 
     /**

--- a/src/api/conversations.js
+++ b/src/api/conversations.js
@@ -1,65 +1,86 @@
 import { BaseApi } from './base';
+import smoochMethod from '../utils/smoochMethod';
 
 /**
  * @typedef Message
- *
  */
 
 /**
- * @class ConversationsApi
+ * @constructor
+ * @name ConversationsApi
  * @extends BaseApi
  */
 export class ConversationsApi extends BaseApi {
+}
 
+Object.assign(ConversationsApi.prototype, {
     /**
      * Fetch an app user's conversation
+     * @memberof ConversationsApi.prototype
+     * @method get
      * @param  {string} userId - a user id
      * @return {APIResponse}
      */
-    get(userId) {
-        const url = this.getFullURL('appUsers', userId, 'conversation');
-        return this.request('GET', url);
-    }
+    get: smoochMethod({
+        params: ['userId'],
+        func: function get(userId) {
+            const url = this.getFullURL('appUsers', userId, 'conversation');
+            return this.request('GET', url);
+        }
+    }),
 
     /**
      * Post back to an action button
+     * @memberof ConversationsApi.prototype
+     * @method postPostback
      * @param  {string} userId - a user id
      * @param  {string} actionId - an action id
      * @return {APIResponse}
      */
-    postPostback(userId, actionId) {
-        if (!actionId) {
-            return Promise.reject(new Error('Must provide an action id.'));
+    postPostback: smoochMethod({
+        params: ['userId', 'actionId'],
+        func: function postPostback(userId, actionId) {
+            if (!actionId) {
+                return Promise.reject(new Error('Must provide an action id.'));
+            }
+
+            const url = this.getFullURL('appUsers', userId, 'conversation', 'postback');
+            const body = {
+                actionId
+            };
+
+            return this.request('POST', url, body);
         }
-
-        const url = this.getFullURL('appUsers', userId, 'conversation', 'postback');
-        const body = {
-            actionId
-        };
-
-        return this.request('POST', url, body);
-    }
+    }),
 
     /**
-     * Deprecated. Use appUsers.sendMessage() instead.
-     */
-    sendMessage() {
-        return Promise.reject(new Error('This endpoint is deprecated. Please use appUsers.sendMessage() instead.'));
-    }
-
-    /**
-     * Deprecated. Use appusers.uploadImage() instead.
-     */
-    uploadImage() {
-        return Promise.reject(new Error('This endpoint is deprecated. Please use appUsers.uploadImage() instead.'));
-    }
-
-    /**
-     * Reset the unread count of the conversation
+     * Reset the unread count of an existing user's conversation
+     * @memberof ConversationsApi.prototype
+     * @method resetUnreadCount
+     * @param  {string} userId - a user id
      * @return {APIResponse}
      */
-    resetUnreadCount(userId) {
-        const url = this.getFullURL('appUsers', userId, 'conversation', 'read');
-        return this.request('POST', url);
+    resetUnreadCount: smoochMethod({
+        params: ['userId'],
+        func: function resetUnreadCount(userId) {
+            const url = this.getFullURL('appUsers', userId, 'conversation', 'read');
+            return this.request('POST', url);
+        }
+    }),
+
+    /**
+     * @memberof ConversationsApi.prototype
+     * @deprecated Use appUsers.sendMessage() instead.
+     */
+    sendMessage: function sendMessage() {
+        return Promise.reject(new Error('This endpoint is deprecated. Please use appUsers.sendMessage() instead.'));
+    },
+
+    /**
+     * @memberof ConversationsApi.prototype
+     * @deprecated Use appUsers.uploadImage() instead.
+     */
+    uploadImage: function uploadImage() {
+        return Promise.reject(new Error('This endpoint is deprecated. Please use appUsers.uploadImage() instead.'));
     }
-}
+});

--- a/src/api/menu.js
+++ b/src/api/menu.js
@@ -1,50 +1,69 @@
 import { BaseApi } from './base';
+import smoochMethod from '../utils/smoochMethod';
 
 /**
- * @class MenuApi
+ * @constructor
+ * @name MenuApi
  * @extends BaseApi
  */
 export class MenuApi extends BaseApi {
-
     constructor() {
         super(...arguments);
         this.allowedAuth = ['jwt'];
     }
+}
+
+Object.assign(MenuApi.prototype, {
 
     /**
      * Fetch an app's menu
+     * @memberof MenuApi.prototype
+     * @method get
      * @return {APIResponse}
      */
-    get() {
-        const url = this.getFullURL('menu');
-        return this.request('GET', url);
-    }
+    get: smoochMethod({
+        params: [],
+        func: function get() {
+            const url = this.getFullURL('menu');
+            return this.request('GET', url);
+        }
+    }),
 
     /**
      * Update an app's menu
-     * @param  {object} menuData
+     * @memberof MenuApi.prototype
+     * @method configure
+     * @param  {object} props
      * @return {APIResponse}
      */
-    configure(menuData) {
-        if (!menuData) {
-            return Promise.reject(new Error('Must provide props.'));
+    configure: smoochMethod({
+        params: ['props'],
+        func: function configure(props) {
+            if (!props) {
+                return Promise.reject(new Error('Must provide props.'));
+            }
+
+            if (!props.items) {
+                return Promise.reject(new Error('Must provide an array of items.'));
+            }
+
+            const url = this.getFullURL('menu');
+
+            return this.request('PUT', url, props);
         }
-
-        if (!menuData.items) {
-            return Promise.reject(new Error('Must provide an array of items.'));
-        }
-
-        const url = this.getFullURL('menu');
-
-        return this.request('PUT', url, menuData);
-    }
+    }),
 
     /**
      * Delete an app's menu
+     * @memberof MenuApi.prototype
+     * @method remove
      * @return {APIResponse}
      */
-    remove() {
-        const url = this.getFullURL('menu');
-        return this.request('DELETE', url);
-    }
-}
+    remove: smoochMethod({
+        params: [],
+        func: function remove() {
+            const url = this.getFullURL('menu');
+            return this.request('DELETE', url);
+        }
+    })
+});

--- a/src/api/stripe.js
+++ b/src/api/stripe.js
@@ -1,15 +1,26 @@
 import { BaseApi } from './base';
-import { http } from '../utils/http';
+import smoochMethod from '../utils/smoochMethod';
 
 /**
- * @class StripeApi
+ * @constructor
+ * @name StripeApi
  * @extends BaseApi
  */
 export class StripeApi extends BaseApi {
-
-    getAccount() {
-        const url = this.getFullURL('stripe', 'account');
-        return this.request('GET', url);
-    }
-
 }
+
+Object.assign(StripeApi.prototype, {
+    /**
+     * Fetch the stripe account associated with an app
+     * @memberof StripeApi.prototype
+     * @method getAccount
+     * @return {APIResponse}
+     */
+    getAccount: smoochMethod({
+        params: [],
+        func: function getAccount() {
+            const url = this.getFullURL('stripe', 'account');
+            return this.request('GET', url);
+        }
+    })
+});

--- a/src/api/webhooks.js
+++ b/src/api/webhooks.js
@@ -1,4 +1,5 @@
 import { BaseApi } from './base';
+import smoochMethod from '../utils/smoochMethod';
 
 /**
  * Webhook properties
@@ -6,90 +7,122 @@ import { BaseApi } from './base';
  */
 
 /**
- * @class WebhooksApi
+ * @constructor
+ * @name WebhooksApi
  * @extends BaseApi
  */
 export class WebhooksApi extends BaseApi {
-
     constructor() {
         super(...arguments);
         this.allowedAuth = ['jwt'];
     }
+}
 
+Object.assign(WebhooksApi.prototype, {
     /**
      * Validates the properties sent to the API
+     * @memberof WebhooksApi.prototype
+     * @method validateProps
      * @param  {WebhookProps}  props      - a properties object
-     * @param  {Boolean} isTargetRequired - tells if the target property is required (i.e., on creation) [default = false]
+     * @param  {boolean} isTargetRequired - tells if the target property is required (i.e., on creation) [default = false]
      * @return {WebhookProps}             - the properties object passed in parameter
      */
-    validateProps(props, isTargetRequired = false) {
-        if (!props || Object.keys(props).length === 0) {
-            return Promise.reject(new Error('Must provide props.'));
-        }
+    validateProps: smoochMethod({
+        params: ['props', 'isTargetRequired'],
+        optional: ['isTargetRequired'],
+        func: function validateProps(props, isTargetRequired = false) {
+            if (!props || Object.keys(props).length === 0) {
+                return Promise.reject(new Error('Must provide props.'));
+            }
 
-        if (isTargetRequired && !props.target) {
-            return Promise.reject(new Error('Must provide a target.'));
-        }
+            if (isTargetRequired && !props.target) {
+                return Promise.reject(new Error('Must provide a target.'));
+            }
 
-        if (props.target && !props.target.startsWith('http://') && !props.target.startsWith('https://')) {
-            return Promise.reject(new Error('Malformed target url.'));
-        }
+            if (props.target && !props.target.startsWith('http://') && !props.target.startsWith('https://')) {
+                return Promise.reject(new Error('Malformed target url.'));
+            }
 
-        return Promise.resolve(props);
-    }
+            return Promise.resolve(props);
+        }
+    }),
 
     /**
      * List all webhooks
-     * @param  {AuthCredentials} auth
+     * @memberof WebhooksApi.prototype
+     * @method list
      * @return {APIResponse}
      */
-    list() {
-        const url = this.getFullURL('webhooks');
-        return this.request('GET', url);
-    }
+    list: smoochMethod({
+        params: [],
+        func: function list() {
+            const url = this.getFullURL('webhooks');
+            return this.request('GET', url);
+        }
+    }),
 
     /**
      * Creates a webhook
+     * @memberof WebhooksApi.prototype
+     * @method create
      * @param  {WebhookProps} props - a properties object
      * @return {APIResponse}
      */
-    create(props) {
-        const url = this.getFullURL('webhooks');
-        return this.validateProps(props, true).then((validatedProps) => {
-            return this.request('POST', url, validatedProps);
-        });
-    }
+    create: smoochMethod({
+        params: ['props'],
+        func: function create(props) {
+            const url = this.getFullURL('webhooks');
+            return this.validateProps(props, true).then((validatedProps) => {
+                return this.request('POST', url, validatedProps);
+            });
+        }
+    }),
 
     /**
      * Retrieves a webhook
+     * @memberof WebhooksApi.prototype
+     * @method get
      * @param  {string} webhookId - an id
      * @return {APIResponse}
      */
-    get(webhookId) {
-        const url = this.getFullURL('webhooks', webhookId);
-        return this.request('GET', url);
-    }
+    get: smoochMethod({
+        params: ['webhookId'],
+        func: function get(webhookId) {
+            const url = this.getFullURL('webhooks', webhookId);
+            return this.request('GET', url);
+        }
+    }),
 
     /**
      * Updates a webhook
+     * @memberof WebhooksApi.prototype
+     * @method update
      * @param  {string} webhookId    - an id
      * @param  {WebhookProps} props  - a properties object
      * @return {APIResponse}
      */
-    update(webhookId, props) {
-        const url = this.getFullURL('webhooks', webhookId);
-        return this.validateProps(props).then((validatedProps) => {
-            return this.request('PUT', url, validatedProps);
-        });
-    }
+    update: smoochMethod({
+        params: ['webhookId', 'props'],
+        func: function update(webhookId, props) {
+            const url = this.getFullURL('webhooks', webhookId);
+            return this.validateProps(props).then((validatedProps) => {
+                return this.request('PUT', url, validatedProps);
+            });
+        }
+    }),
 
     /**
      * Deletes a webhook
+     * @memberof WebhooksApi.prototype
+     * @method delete
      * @param  {string} webhookId - an id
      * @return {APIResponse}
      */
-    delete(webhookId) {
-        const url = this.getFullURL('webhooks', webhookId);
-        return this.request('DELETE', url);
-    }
-}
+    delete: smoochMethod({
+        params: ['webhookId'],
+        func: function del(webhookId) {
+            const url = this.getFullURL('webhooks', webhookId);
+            return this.request('DELETE', url);
+        }
+    })
+});

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -6,6 +6,7 @@ import packageInfo from '../package.json';
 
 export const SERVICE_URL = 'https://api.smooch.io/v1';
 
+
 export class Smooch {
     constructor(auth = {}, options = {}) {
         const {serviceUrl = SERVICE_URL, headers = {}} = options;

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -6,7 +6,6 @@ import packageInfo from '../package.json';
 
 export const SERVICE_URL = 'https://api.smooch.io/v1';
 
-
 export class Smooch {
     constructor(auth = {}, options = {}) {
         const {serviceUrl = SERVICE_URL, headers = {}} = options;

--- a/src/utils/smoochMethod.js
+++ b/src/utils/smoochMethod.js
@@ -28,7 +28,7 @@ export default function smoochMethod({params, optional=[], func}) {
                 });
             }
         } else {
-            args = [].slice.call(arguments);
+            args = [...arguments];
         }
 
         if (args.length < requiredParams.length) {

--- a/src/utils/smoochMethod.js
+++ b/src/utils/smoochMethod.js
@@ -1,0 +1,38 @@
+export default function smoochMethod({params, func}) {
+    return function() {
+        let args;
+        const implicitAppId = params.includes('appId') && !this.requireAppId;
+        const expectedParams = implicitAppId ? params.filter((p) => p !== 'appId') : params;
+
+        if (typeof arguments[0] === 'object' && arguments.length === 1) {
+            const paramObject = arguments[0];
+            if (params.includes('props') &&
+                typeof paramObject.props !== 'object') {
+                // func accepts a single object arg called props
+                // and it's not wrapped inside any outer object
+                args = [paramObject];
+            } else {
+                // Map the object params into an array of args
+                args = expectedParams.map((param) => {
+                    if (!paramObject[param]) {
+                        throw new Error(`${func.name}: missing required argument: ${param}`);
+                    }
+                    return paramObject[param];
+                });
+            }
+        } else {
+            args = [].slice.call(arguments);
+        }
+
+        if (args.length !== expectedParams.length) {
+            throw new Error(`${func.name}: incorrect number of parameters (${args.length}). Expected ${expectedParams.length}`);
+        }
+
+        // appId param is used by func, but in this case its not required, so pad the arg list
+        if (implicitAppId) {
+            args.unshift(undefined);
+        }
+
+        return func.apply(this, args);
+    };
+}

--- a/test-setup.js
+++ b/test-setup.js
@@ -5,4 +5,4 @@ chai.use(sinonChai);
 
 global.sinon = sinon;
 global.expect = chai.expect;
-global.should = chai.should()
+global.should = chai.should();

--- a/test/specs/api/appUsersStripe.spec.js
+++ b/test/specs/api/appUsersStripe.spec.js
@@ -32,9 +32,7 @@ describe('AppUsersStripe API', () => {
         });
 
         it('should throw if no token provided', () => {
-            return api.updateCustomer(userId).catch(() => {
-                httpSpy.should.not.have.been.called;
-            });
+            expect(() => api.updateCustomer(userId)).to.throw(Error, 'incorrect number of parameters');
         });
 
         describe('with app-token', () => {

--- a/test/specs/api/webhooks.spec.js
+++ b/test/specs/api/webhooks.spec.js
@@ -28,11 +28,8 @@ describe('Webhooks API', () => {
     });
 
     describe('#validateProps', () => {
-        it('should return an error if props are not provided', (done) => {
-            api.validateProps().catch((e) => {
-                e.message.should.equal(noPropsMessage);
-                done();
-            });
+        it('should return an error if props are not provided', () => {
+            expect(() => api.validateProps()).to.throw(Error, 'incorrect number of parameters');
         });
 
         it('should return an error if props are empty', (done) => {

--- a/test/specs/utils/smoochMethod.spec.js
+++ b/test/specs/utils/smoochMethod.spec.js
@@ -1,0 +1,218 @@
+import { BaseApi } from '../../../src/api/base';
+import smoochMethod from '../../../src/utils/smoochMethod';
+
+const serviceUrl = 'http://example.org/v1';
+const appId = 'appId';
+const param1 = 'foo';
+
+/**
+ * Foos things
+ * @constructor
+ * @name Fooer
+ */
+class TestApi extends BaseApi {
+}
+
+Object.assign(TestApi.prototype, {
+    /**
+     * Uses appId param if its needed
+     * @memberof TestApi.prototype
+     * @method usesAppId
+     * @param {string} appId - The app id
+     * @param {string} param1 - The second param
+     */
+    usesAppId: smoochMethod({
+        params: ['appId', 'param1'],
+        func: function usesAppId(appId, param1) {
+            return this.getFullURLWithApp(appId, 'param1', param1);
+        }
+    }),
+
+    /**
+     * Doesn't use the appId param
+     * @memberof TestApi.prototype
+     * @method noAppId
+     * @param {string} param1 - The first param
+     */
+    noAppId: smoochMethod({
+        params: ['param1'],
+        func: function noAppId(param1) {
+            return this.getFullURL('param1', param1);
+        }
+    }),
+
+    /**
+     * Accepts three params
+     * @memberof TestApi.prototype
+     * @method manyParams
+     * @param {string} param1 - The first param
+     * @param {string} param2 - The second param
+     * @param {string} param3 - The third param
+     */
+    manyParams: smoochMethod({
+        params: ['param1', 'param2', 'param3'],
+        func: function manyParams(param1, param2, param3) {
+            return this.getFullURL('param1', param1, 'param2', param2, 'param3', param3);
+        }
+    }),
+
+    /**
+     * Accepts a props object
+     * @memberof TestApi.prototype
+     * @method singleProps
+     * @param {object} props - Props
+     */
+    singleProps: smoochMethod({
+        params: ['props'],
+        func: function singleProps(props) {
+            return props;
+        }
+    }),
+
+    /**
+     * Accepts no params
+     * @memberof TestApi.prototype
+     * @method noParams 
+     */
+    noParams: smoochMethod({
+        params: [],
+        func: function noParams() {}
+    })
+});
+
+describe('Smooch Method', () => {
+    let testApi;
+
+    describe('method requires appId', () => {
+        beforeEach(() => {
+            testApi = new TestApi(serviceUrl, {}, {}, true);
+        });
+
+        it('should accept param list with appId', () => {
+            const result = testApi.usesAppId(appId, param1);
+            result.should.equal(`${serviceUrl}/apps/${appId}/param1/${param1}`);
+        });
+
+        it('should reject param list missing appId', () => {
+            expect(() => testApi.usesAppId(param1)).to.throw(Error, 'incorrect number of parameters');
+        });
+
+        it('should accept object with appId', () => {
+            const result = testApi.usesAppId({appId, param1});
+            result.should.equal(`${serviceUrl}/apps/${appId}/param1/${param1}`);
+        });
+
+        it('should reject object missing appId', () => {
+            expect(() => testApi.usesAppId({param1})).to.throw(Error, 'missing required argument');
+        });
+    });
+
+    describe('method does not use appId', () => {
+        beforeEach(() => {
+            testApi = new TestApi(serviceUrl, {}, {}, true);
+        });
+
+        it('should accept param list', () => {
+            const result = testApi.noAppId(param1);
+            result.should.equal(`${serviceUrl}/param1/${param1}`);
+        });
+
+        it('should accept object', () => {
+            const result = testApi.noAppId({param1});
+            result.should.equal(`${serviceUrl}/param1/${param1}`);
+        });
+
+        it('should reject appId in param list', () => {
+            expect(() => testApi.noAppId(appId, param1)).to.throw(Error, 'incorrect number of parameters');
+        });
+
+        it('should ignore appId in object', () => {
+            const result = testApi.noAppId({appId, param1});
+            result.should.equal(`${serviceUrl}/param1/${param1}`);
+        });
+    });
+
+    describe('appId resolved by credential scope', () => {
+        beforeEach(() => {
+            testApi = new TestApi(serviceUrl, {}, {}, false);
+        });
+
+        it('should accept param list', () => {
+            const result = testApi.usesAppId(param1);
+            result.should.equal(`${serviceUrl}/param1/${param1}`);
+        });
+
+        it('should reject param list with appId', () => {
+            expect(() => testApi.usesAppId(appId, param1)).to.throw(Error, 'incorrect number of parameters');
+        });
+
+        it('should accept object', () => {
+            const result = testApi.usesAppId({param1});
+            result.should.equal(`${serviceUrl}/param1/${param1}`);
+        });
+
+        it('should ignore appId in object', () => {
+            const result = testApi.usesAppId({appId, param1});
+            result.should.equal(`${serviceUrl}/param1/${param1}`);
+        });
+    });
+
+    describe('many params', () => {
+        const param2 = 'bar';
+        const param3 = 'baz';
+
+        beforeEach(() => {
+            testApi = new TestApi(serviceUrl, {}, {}, false);
+        });
+
+        it('should accept param list', () => {
+            const result = testApi.manyParams(param1, param2, param3);
+            result.should.equal(`${serviceUrl}/param1/${param1}/param2/${param2}/param3/${param3}`);
+        });
+
+        it('should accept object', () => {
+            const result = testApi.manyParams({param1, param2, param3});
+            result.should.equal(`${serviceUrl}/param1/${param1}/param2/${param2}/param3/${param3}`);
+        });
+    });
+
+    describe('method with single props arg', () => {
+        let props;
+        beforeEach(() => {
+            testApi = new TestApi(serviceUrl, {}, {}, false);
+            props = {
+                a: 'foo',
+                b: 'bar'
+            };
+        });
+
+        it('should accept param list', () => {
+            const result = testApi.singleProps(props);
+            result.should.deep.equal(props);
+        });
+
+        it('should accept object', () => {
+            const result = testApi.singleProps({props});
+            result.should.deep.equal(props);
+        });
+    });
+
+    describe('method with no params', () => {
+
+        beforeEach(() => {
+            testApi = new TestApi(serviceUrl, {}, {}, false);
+        });
+
+        it('should accept no params', () => {
+            testApi.noParams();
+        });
+
+        it('should reject param list', () => {
+            expect(() => testApi.noParams('banana')).to.throw(Error);
+        });
+
+        it('should ignore object', () => {
+            testApi.noParams({foo: 'bar'});
+        });
+    });
+});

--- a/test/specs/utils/smoochMethod.spec.js
+++ b/test/specs/utils/smoochMethod.spec.js
@@ -77,6 +77,19 @@ Object.assign(TestApi.prototype, {
     noParams: smoochMethod({
         params: [],
         func: function noParams() {}
+    }),
+
+    /**
+     * Accepts optional params
+     * @memberof TestApi.prototype
+     * @method optionalParams
+     */
+    optionalParams: smoochMethod({
+        params: ['param1', 'param2'],
+        optional: ['param2'],
+        func: function optionalParams(param1, param2 = 'default') {
+            return [param1, param2];
+        }
     })
 });
 
@@ -98,12 +111,17 @@ describe('Smooch Method', () => {
         });
 
         it('should accept object with appId', () => {
-            const result = testApi.usesAppId({appId, param1});
+            const result = testApi.usesAppId({
+                appId,
+                param1
+            });
             result.should.equal(`${serviceUrl}/apps/${appId}/param1/${param1}`);
         });
 
         it('should reject object missing appId', () => {
-            expect(() => testApi.usesAppId({param1})).to.throw(Error, 'missing required argument');
+            expect(() => testApi.usesAppId({
+                param1
+            })).to.throw(Error, 'missing required argument');
         });
     });
 
@@ -118,7 +136,9 @@ describe('Smooch Method', () => {
         });
 
         it('should accept object', () => {
-            const result = testApi.noAppId({param1});
+            const result = testApi.noAppId({
+                param1
+            });
             result.should.equal(`${serviceUrl}/param1/${param1}`);
         });
 
@@ -127,7 +147,10 @@ describe('Smooch Method', () => {
         });
 
         it('should ignore appId in object', () => {
-            const result = testApi.noAppId({appId, param1});
+            const result = testApi.noAppId({
+                appId,
+                param1
+            });
             result.should.equal(`${serviceUrl}/param1/${param1}`);
         });
     });
@@ -147,12 +170,17 @@ describe('Smooch Method', () => {
         });
 
         it('should accept object', () => {
-            const result = testApi.usesAppId({param1});
+            const result = testApi.usesAppId({
+                param1
+            });
             result.should.equal(`${serviceUrl}/param1/${param1}`);
         });
 
         it('should ignore appId in object', () => {
-            const result = testApi.usesAppId({appId, param1});
+            const result = testApi.usesAppId({
+                appId,
+                param1
+            });
             result.should.equal(`${serviceUrl}/param1/${param1}`);
         });
     });
@@ -171,7 +199,11 @@ describe('Smooch Method', () => {
         });
 
         it('should accept object', () => {
-            const result = testApi.manyParams({param1, param2, param3});
+            const result = testApi.manyParams({
+                param1,
+                param2,
+                param3
+            });
             result.should.equal(`${serviceUrl}/param1/${param1}/param2/${param2}/param3/${param3}`);
         });
     });
@@ -192,13 +224,14 @@ describe('Smooch Method', () => {
         });
 
         it('should accept object', () => {
-            const result = testApi.singleProps({props});
+            const result = testApi.singleProps({
+                props
+            });
             result.should.deep.equal(props);
         });
     });
 
     describe('method with no params', () => {
-
         beforeEach(() => {
             testApi = new TestApi(serviceUrl, {}, {}, false);
         });
@@ -212,7 +245,36 @@ describe('Smooch Method', () => {
         });
 
         it('should ignore object', () => {
-            testApi.noParams({foo: 'bar'});
+            testApi.noParams({
+                foo: 'bar'
+            });
+        });
+    });
+
+    describe('method with optional params', () => {
+        const param2 = 'bar';
+        beforeEach(() => {
+            testApi = new TestApi(serviceUrl, {}, {}, false);
+        });
+
+        it('should accept full param list', () => {
+            const result = testApi.optionalParams(param1, param2);
+            result.should.deep.equal([param1, param2]);
+        });
+
+        it('should accept full object', () => {
+            const result = testApi.optionalParams({param1, param2});
+            result.should.deep.equal([param1, param2]);
+        });
+
+        it('should accept only required param list', () => {
+            const result = testApi.optionalParams(param1);
+            result.should.deep.equal([param1, 'default']);
+        });
+
+        it('should accept only required object', () => {
+            const result = testApi.optionalParams({param1});
+            result.should.deep.equal([param1, 'default']);
         });
     });
 });

--- a/test/specs/utils/smoochMethod.spec.js
+++ b/test/specs/utils/smoochMethod.spec.js
@@ -83,6 +83,8 @@ Object.assign(TestApi.prototype, {
      * Accepts optional params
      * @memberof TestApi.prototype
      * @method optionalParams
+     * @param {string} param1 - The first param
+     * @param {string=} props - The second param
      */
     optionalParams: smoochMethod({
         params: ['param1', 'param2'],


### PR DESCRIPTION
smoochMethod allows API methods to be called with a conventional
argument list or with a params object. Some methods also accept an appId
parameter, which becomes a required parameter when the SDK is
initialized with account scope. smoochMethod will automatically handle
validation of this appId parameter.


This PR updates existing APIs to use smoochMethod. I've also cleaned up some of the jsdoc comment blocks while I was at it. We may soon have decent auto-generated docs for this repo!

Support for account scope and appId param handling will come in a subsequent PR.