### PR TITLE
F/implicit appid

### DIFF
--- a/src/api/appUsers.js
+++ b/src/api/appUsers.js
@@ -33,10 +33,8 @@ Object.assign(AppUsersApi.prototype, {
      */
     init: smoochMethod({
         params: ['props'],
-        func: function init(props) {
-            const url = this.getFullURL('init');
-            return this.request('POST', url, props);
-        }
+        path: '/init',
+        method: 'POST'
     }),
 
     /**
@@ -50,7 +48,8 @@ Object.assign(AppUsersApi.prototype, {
     create: smoochMethod({
         params: ['userId', 'props'],
         optional: ['props'],
-        func: function create(userId, props = {}) {
+        path: '/appusers',
+        func: function create(url, userId, props = {}) {
             if (!userId || !userId.trim()) {
                 return Promise.reject(new Error('Must provide a userId.'));
             }
@@ -62,8 +61,6 @@ Object.assign(AppUsersApi.prototype, {
             if (props.signedUpAt && !(props.signedUpAt instanceof Date)) {
                 return Promise.reject(new Error('signedUpAt must be a date.'));
             }
-
-            const url = this.getFullURL('appusers');
 
             // this endpoint only accepts JWT auth with app scope
             return this.request('POST', url, payload, {
@@ -81,10 +78,8 @@ Object.assign(AppUsersApi.prototype, {
      */
     get: smoochMethod({
         params: ['userId'],
-        func: function get(userId) {
-            const url = this.getFullURL('appusers', userId);
-            return this.request('GET', url);
-        }
+        path: '/appusers/:userId',
+        method: 'GET'
     }),
 
     /**
@@ -97,10 +92,8 @@ Object.assign(AppUsersApi.prototype, {
      */
     update: smoochMethod({
         params: ['userId', 'props'],
-        func: function update(userId, props) {
-            const url = this.getFullURL('appusers', userId);
-            return this.request('PUT', url, props);
-        }
+        path: '/appusers/:userId',
+        method: 'PUT'
     }),
 
     /**
@@ -115,8 +108,8 @@ Object.assign(AppUsersApi.prototype, {
     trackEvent: smoochMethod({
         params: ['userId', 'eventName', 'props'],
         optional: ['props'],
-        func: function trackEvent(userId, eventName, props = {}) {
-            const url = this.getFullURL('appusers', userId, 'events');
+        path: '/appusers/:userId/events',
+        func: function trackEvent(url, userId, eventName, props = {}) {
             return this.request('POST', url, {
                 name: eventName,
                 appUser: props
@@ -135,8 +128,8 @@ Object.assign(AppUsersApi.prototype, {
      */
     updatePushToken: smoochMethod({
         params: ['userId', 'deviceId', 'token'],
-        func: function updatePushToken(userId, deviceId, token) {
-            const url = this.getFullURL('appusers', userId, 'pushToken');
+        path: '/appusers/:userId/pushToken',
+        func: function updatePushToken(url, userId, deviceId, token) {
             return this.request('POST', url, {
                 deviceId,
                 token
@@ -154,10 +147,8 @@ Object.assign(AppUsersApi.prototype, {
     */
     updateDevice: smoochMethod({
         params: ['userId', 'deviceId', 'props'],
-        func: function updateDevice(userId, deviceId, props) {
-            const url = this.getFullURL('appusers', userId, 'devices', deviceId);
-            return this.request('PUT', url, props);
-        }
+        path: '/appusers/:userId/devices/:deviceId',
+        method: 'PUT'
     }),
 
     /**
@@ -170,14 +161,8 @@ Object.assign(AppUsersApi.prototype, {
      */
     linkChannel: smoochMethod({
         params: ['userId', 'data'],
-        func: function linkChannel(userId, data) {
-            if (!data.type) {
-                return Promise.reject(new Error('Must provide a channel type.'));
-            }
-
-            const url = this.getFullURL('appUsers', userId, 'channels');
-            return this.request('POST', url, data);
-        }
+        path: '/appusers/:userId/channels',
+        method: 'POST'
     }),
 
     /**
@@ -190,10 +175,8 @@ Object.assign(AppUsersApi.prototype, {
      */
     unlinkChannel: smoochMethod({
         params: ['userId', 'channel'],
-        func: function unlinkChannel(userId, channel) {
-            const url = this.getFullURL('appUsers', userId, 'channels', channel);
-            return this.request('DELETE', url);
-        }
+        path: '/appusers/:userId/channels/:channel',
+        method: 'DELETE'
     }),
 
     /**
@@ -206,8 +189,8 @@ Object.assign(AppUsersApi.prototype, {
      */
     pingChannel: smoochMethod({
         params: ['userId', 'channel'],
-        func: function pingChannel(userId, channel) {
-            const url = this.getFullURL('appUsers', userId, 'integrations', channel, 'ping');
+        path: '/appusers/:userId/integrations/:channel/ping',
+        func: function pingChannel(url) {
             return this.request('POST', url);
         }
     }),
@@ -223,7 +206,8 @@ Object.assign(AppUsersApi.prototype, {
     getMessages: smoochMethod({
         params: ['userId', 'query'],
         optional: ['query'],
-        func: function getMessages(userId, query = {}) {
+        path: '/appusers/:userId/messages',
+        func: function getMessages(url, userId, query = {}) {
             const {before, after} = query;
             if (before && after) {
                 return Promise.reject(new Error('Parameters "before" and "after" are mutually exclusive. You must provide one or the other.'));
@@ -234,7 +218,6 @@ Object.assign(AppUsersApi.prototype, {
             } : after ? {
                 after
             } : undefined;
-            const url = this.getFullURL('appUsers', userId, 'messages');
             return this.request('GET', url, q);
         }
     }),
@@ -249,10 +232,8 @@ Object.assign(AppUsersApi.prototype, {
      */
     sendMessage: smoochMethod({
         params: ['userId', 'message'],
-        func: function sendMessage(userId, message) {
-            const url = this.getFullURL('appUsers', userId, 'messages');
-            return this.request('POST', url, message);
-        }
+        path: '/appusers/:userId/messages',
+        method: 'POST'
     }),
 
     /**
@@ -267,8 +248,8 @@ Object.assign(AppUsersApi.prototype, {
     uploadImage: smoochMethod({
         params: ['userId', 'source', 'message'],
         optional: ['message'],
-        func: function uploadImage(userId, source, message = {}) {
-            const url = this.getFullURL('appUsers', userId, 'images');
+        path: '/appusers/:userId/images',
+        func: function uploadImage(url, userId, source, message = {}) {
             const data = new FormData();
             data.append('source', source);
 

--- a/src/api/appUsersStripe.js
+++ b/src/api/appUsersStripe.js
@@ -20,12 +20,12 @@ Object.assign(AppUsersStripeApi.prototype, {
      */
     updateCustomer: smoochMethod({
         params: ['userId', 'token'],
-        func: function updateCustomer(userId, token) {
+        path: '/appusers/:userId/stripe/customer',
+        func: function updateCustomer(url, userId, token) {
             if (!token) {
                 return Promise.reject(new Error('Must provide a Stripe token.'));
             }
 
-            const url = this.getFullURL('appUsers', userId, 'stripe', 'customer');
             return this.request('POST', url, {
                 token
             }, {
@@ -46,12 +46,11 @@ Object.assign(AppUsersStripeApi.prototype, {
     createTransaction: smoochMethod({
         params: ['userId', 'actionId', 'token'],
         optional: ['token'],
-        func: function createTransaction(userId, actionId, token) {
+        path: '/appusers/:userId/stripe/transaction',
+        func: function createTransaction(url, userId, actionId, token) {
             if (!actionId) {
                 return Promise.reject(new Error('Must provide an action id.'));
             }
-
-            const url = this.getFullURL('appUsers', userId, 'stripe', 'transaction');
 
             const body = {
                 actionId

--- a/src/api/appUsersViber.js
+++ b/src/api/appUsersViber.js
@@ -19,9 +19,7 @@ Object.assign(AppUsersViberApi.prototype, {
      */
     getQRCode: smoochMethod({
         params: ['userId'],
-        func: function getQRCode(userId) {
-            const url = this.getFullURL('appUsers', userId, 'integrations', 'viber', 'qrcode');
-            return this.request('GET', url);
-        }
+        path: '/appusers/:userId/integrations/viber/qrcode',
+        method: 'GET'
     })
 });

--- a/src/api/appUsersWeChat.js
+++ b/src/api/appUsersWeChat.js
@@ -19,9 +19,7 @@ Object.assign(AppUsersWeChatApi.prototype, {
      */
     getQRCode: smoochMethod({
         params: ['userId'],
-        func: function getQRCode(userId) {
-            const url = this.getFullURL('appUsers', userId, 'integrations', 'wechat', 'qrcode');
-            return this.request('GET', url);
-        }
+        path: '/appusers/:userId/integrations/wechat/qrcode',
+        method: 'GET'
     })
 });

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -1,4 +1,3 @@
-import { urljoin } from '../utils/http';
 import { http } from '../utils/http';
 
 /**
@@ -21,30 +20,6 @@ export class BaseApi {
 
         // both are allowed unless stated otherwise
         this.allowedAuth = ['jwt', 'appToken'];
-    }
-
-    /**
-     * Build an URL from fragments to call the API
-     * @return {string} - an URL
-     */
-    getFullURL(...args) {
-        const fragments = args.map((a) => encodeURIComponent(a));
-        return urljoin(this.serviceUrl, ...fragments);
-    }
-
-    /**
-     * Build an URL from fragments to call the API
-     * Automatically append /apps/ if required, and remove appId fragment if
-     * it is undefined if not required
-     * @return {string} - an URL
-     */
-    getFullURLWithApp(...args) {
-        if (this.requireAppId) {
-            args.unshift('apps');
-        } else {
-            args = args.filter((a) => a !== undefined);
-        }
-        return this.getFullURL(...args);
     }
 
     /**

--- a/src/api/conversations.js
+++ b/src/api/conversations.js
@@ -23,10 +23,8 @@ Object.assign(ConversationsApi.prototype, {
      */
     get: smoochMethod({
         params: ['userId'],
-        func: function get(userId) {
-            const url = this.getFullURL('appUsers', userId, 'conversation');
-            return this.request('GET', url);
-        }
+        path: '/appusers/:userId/conversation',
+        method: 'GET'
     }),
 
     /**
@@ -39,12 +37,12 @@ Object.assign(ConversationsApi.prototype, {
      */
     postPostback: smoochMethod({
         params: ['userId', 'actionId'],
-        func: function postPostback(userId, actionId) {
+        path: '/appusers/:userId/conversation/postback',
+        func: function postPostback(url, userId, actionId) {
             if (!actionId) {
                 return Promise.reject(new Error('Must provide an action id.'));
             }
 
-            const url = this.getFullURL('appUsers', userId, 'conversation', 'postback');
             const body = {
                 actionId
             };
@@ -62,8 +60,8 @@ Object.assign(ConversationsApi.prototype, {
      */
     resetUnreadCount: smoochMethod({
         params: ['userId'],
-        func: function resetUnreadCount(userId) {
-            const url = this.getFullURL('appUsers', userId, 'conversation', 'read');
+        path: '/appusers/:userId/conversation/read',
+        func: function resetUnreadCount(url) {
             return this.request('POST', url);
         }
     }),

--- a/src/api/menu.js
+++ b/src/api/menu.js
@@ -23,10 +23,8 @@ Object.assign(MenuApi.prototype, {
      */
     get: smoochMethod({
         params: [],
-        func: function get() {
-            const url = this.getFullURL('menu');
-            return this.request('GET', url);
-        }
+        path: '/menu',
+        method: 'GET'
     }),
 
     /**
@@ -38,7 +36,8 @@ Object.assign(MenuApi.prototype, {
      */
     configure: smoochMethod({
         params: ['props'],
-        func: function configure(props) {
+        path: '/menu',
+        func: function configure(url, props) {
             if (!props) {
                 return Promise.reject(new Error('Must provide props.'));
             }
@@ -46,8 +45,6 @@ Object.assign(MenuApi.prototype, {
             if (!props.items) {
                 return Promise.reject(new Error('Must provide an array of items.'));
             }
-
-            const url = this.getFullURL('menu');
 
             return this.request('PUT', url, props);
         }
@@ -61,9 +58,7 @@ Object.assign(MenuApi.prototype, {
      */
     remove: smoochMethod({
         params: [],
-        func: function remove() {
-            const url = this.getFullURL('menu');
-            return this.request('DELETE', url);
-        }
+        path: '/menu',
+        method: 'DELETE'
     })
 });

--- a/src/api/stripe.js
+++ b/src/api/stripe.js
@@ -18,9 +18,7 @@ Object.assign(StripeApi.prototype, {
      */
     getAccount: smoochMethod({
         params: [],
-        func: function getAccount() {
-            const url = this.getFullURL('stripe', 'account');
-            return this.request('GET', url);
-        }
+        path: '/stripe/account',
+        method: 'GET'
     })
 });

--- a/src/api/webhooks.js
+++ b/src/api/webhooks.js
@@ -16,9 +16,7 @@ export class WebhooksApi extends BaseApi {
         super(...arguments);
         this.allowedAuth = ['jwt'];
     }
-}
 
-Object.assign(WebhooksApi.prototype, {
     /**
      * Validates the properties sent to the API
      * @memberof WebhooksApi.prototype
@@ -27,26 +25,24 @@ Object.assign(WebhooksApi.prototype, {
      * @param  {boolean} isTargetRequired - tells if the target property is required (i.e., on creation) [default = false]
      * @return {WebhookProps}             - the properties object passed in parameter
      */
-    validateProps: smoochMethod({
-        params: ['props', 'isTargetRequired'],
-        optional: ['isTargetRequired'],
-        func: function validateProps(props, isTargetRequired = false) {
-            if (!props || Object.keys(props).length === 0) {
-                return Promise.reject(new Error('Must provide props.'));
-            }
-
-            if (isTargetRequired && !props.target) {
-                return Promise.reject(new Error('Must provide a target.'));
-            }
-
-            if (props.target && !props.target.startsWith('http://') && !props.target.startsWith('https://')) {
-                return Promise.reject(new Error('Malformed target url.'));
-            }
-
-            return Promise.resolve(props);
+    validateProps(props, isTargetRequired = false) {
+        if (!props || Object.keys(props).length === 0) {
+            return Promise.reject(new Error('Must provide props.'));
         }
-    }),
 
+        if (isTargetRequired && !props.target) {
+            return Promise.reject(new Error('Must provide a target.'));
+        }
+
+        if (props.target && !props.target.startsWith('http://') && !props.target.startsWith('https://')) {
+            return Promise.reject(new Error('Malformed target url.'));
+        }
+
+        return Promise.resolve(props);
+    }
+}
+
+Object.assign(WebhooksApi.prototype, {
     /**
      * List all webhooks
      * @memberof WebhooksApi.prototype
@@ -55,10 +51,8 @@ Object.assign(WebhooksApi.prototype, {
      */
     list: smoochMethod({
         params: [],
-        func: function list() {
-            const url = this.getFullURL('webhooks');
-            return this.request('GET', url);
-        }
+        path: '/webhooks',
+        method: 'GET'
     }),
 
     /**
@@ -70,8 +64,9 @@ Object.assign(WebhooksApi.prototype, {
      */
     create: smoochMethod({
         params: ['props'],
-        func: function create(props) {
-            const url = this.getFullURL('webhooks');
+        path: '/webhooks',
+        func: function create(url, props) {
+            this.validateProps(props);
             return this.validateProps(props, true).then((validatedProps) => {
                 return this.request('POST', url, validatedProps);
             });
@@ -87,10 +82,8 @@ Object.assign(WebhooksApi.prototype, {
      */
     get: smoochMethod({
         params: ['webhookId'],
-        func: function get(webhookId) {
-            const url = this.getFullURL('webhooks', webhookId);
-            return this.request('GET', url);
-        }
+        path: '/webhooks/:webhookId',
+        method: 'GET'
     }),
 
     /**
@@ -103,8 +96,8 @@ Object.assign(WebhooksApi.prototype, {
      */
     update: smoochMethod({
         params: ['webhookId', 'props'],
-        func: function update(webhookId, props) {
-            const url = this.getFullURL('webhooks', webhookId);
+        path: '/webhooks/:webhookId',
+        func: function update(url, webhookId, props) {
             return this.validateProps(props).then((validatedProps) => {
                 return this.request('PUT', url, validatedProps);
             });
@@ -120,9 +113,7 @@ Object.assign(WebhooksApi.prototype, {
      */
     delete: smoochMethod({
         params: ['webhookId'],
-        func: function del(webhookId) {
-            const url = this.getFullURL('webhooks', webhookId);
-            return this.request('DELETE', url);
-        }
+        path: '/webhooks/:webhookId',
+        method: 'DELETE'
     })
 });

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -19,7 +19,7 @@ if (typeof process !== 'undefined') {
 export function stringifyGETParams(url, data) {
     const query = Object.keys(data).reduce((q, key) => {
         if (data[key] !== null) {
-            return q +  '&' + encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
+            return q + '&' + encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
         }
         return q;
     }, '');
@@ -85,8 +85,3 @@ export function http(method, url, data, headers = {}) {
         .then(handleBody);
 }
 
-export function urljoin(...args) {
-    return args.map((part) => {
-        return part.replace(/\/$/, '');
-    }).join('/');
-}

--- a/src/utils/smoochMethod.js
+++ b/src/utils/smoochMethod.js
@@ -1,4 +1,4 @@
-export default function smoochMethod({params, optional=[], path, func}) {
+export default function smoochMethod({params, optional=[], path, method, func}) {
     return function() {
         let args;
         let allParams = params;
@@ -51,12 +51,20 @@ export default function smoochMethod({params, optional=[], path, func}) {
         });
 
         const url = this.serviceUrl + renderedPath;
+        if (method) {
+            if (['POST', 'PUT'].includes(method)) {
+                // Payload object must always specified in the last arg
+                return this.request(method, url, args.pop());
+            } else {
+                return this.request(method, url);
+            }
+        }
+
         if (this.requireAppId) {
             args[0] = url;
         } else {
             args.unshift(url);
         }
-
         return func.apply(this, args);
     };
 }

--- a/test/specs/api/appUsers.spec.js
+++ b/test/specs/api/appUsers.spec.js
@@ -34,7 +34,7 @@ describe('AppUsers API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(userId).then(() => {
-                const fullUrl = api.getFullURL('appusers', userId);
+                const fullUrl = `${serviceUrl}/appusers/${userId}`;
 
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
@@ -48,7 +48,7 @@ describe('AppUsers API', () => {
             };
 
             return api.update(userId, attributes).then(() => {
-                const fullUrl = api.getFullURL('appusers', userId);
+                const fullUrl = `${serviceUrl}/appusers/${userId}`;
                 httpSpy.should.have.been.calledWith('PUT', fullUrl, attributes, httpHeaders);
             });
         });
@@ -61,7 +61,7 @@ describe('AppUsers API', () => {
             };
 
             return api.init(props).then(() => {
-                const fullUrl = api.getFullURL('init');
+                const fullUrl = `${serviceUrl}/init`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, props, httpHeaders);
             });
         });
@@ -88,7 +88,7 @@ describe('AppUsers API', () => {
         it('should call http', () => {
             const jwtApi = new AppUsersApi(serviceUrl, jwtHttpHeaders);
             return jwtApi.create(userId, props).then(() => {
-                const fullUrl = jwtApi.getFullURL('appusers');
+                const fullUrl = `${serviceUrl}/appusers`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, Object.assign({
                     userId: userId
                 }, props), jwtHttpHeaders);
@@ -113,7 +113,7 @@ describe('AppUsers API', () => {
             };
 
             return api.trackEvent(userId, eventName, props).then(() => {
-                const fullUrl = api.getFullURL('appusers', userId, 'events');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/events`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, {
                     name: eventName,
                     appUser: props
@@ -128,7 +128,7 @@ describe('AppUsers API', () => {
             const token = 'some-token';
 
             return api.updatePushToken(userId, deviceId, token).then(() => {
-                const fullUrl = api.getFullURL('appusers', userId, 'pushToken');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/pushToken`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, {
                     deviceId,
                     token
@@ -145,7 +145,7 @@ describe('AppUsers API', () => {
             };
 
             return api.updateDevice(userId, deviceId, attrs).then(() => {
-                const fullUrl = api.getFullURL('appusers', userId, 'devices', deviceId);
+                const fullUrl = `${serviceUrl}/appusers/${userId}/devices/${deviceId}`;
                 httpSpy.should.have.been.calledWith('PUT', fullUrl, attrs, httpHeaders);
             });
         });
@@ -158,7 +158,7 @@ describe('AppUsers API', () => {
                 phoneNumber: '15145555555'
             };
             return api.linkChannel(userId, data).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'channels');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/channels`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, {
                     ...data
                 }, httpHeaders);
@@ -175,7 +175,7 @@ describe('AppUsers API', () => {
     describe('#unlinkChannel', () => {
         it('should call http', () => {
             return api.unlinkChannel(userId, 'twilio').then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'channels', 'twilio');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/channels/twilio`;
                 httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, httpHeaders);
             });
         });
@@ -184,7 +184,7 @@ describe('AppUsers API', () => {
     describe('#pingChannel', () => {
         it('should call http', () => {
             return api.pingChannel(userId, 'twilio').then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'integrations', 'twilio', 'ping');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/integrations/twilio/ping`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, undefined, httpHeaders);
             });
         });
@@ -193,7 +193,7 @@ describe('AppUsers API', () => {
     describe('#getMessages', () => {
         it('should call http', () => {
             return api.getMessages(userId).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'messages');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
@@ -202,7 +202,7 @@ describe('AppUsers API', () => {
             return api.getMessages(userId, {
                 before: 'XYZ'
             }).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'messages');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, {
                     before: 'XYZ'
                 }, httpHeaders);
@@ -213,7 +213,7 @@ describe('AppUsers API', () => {
             return api.getMessages(userId, {
                 after: 'XYZ'
             }).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'messages');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, {
                     after: 'XYZ'
                 }, httpHeaders);
@@ -237,7 +237,7 @@ describe('AppUsers API', () => {
             };
 
             return api.sendMessage(userId, message).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'messages');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, message, httpHeaders);
             });
         });
@@ -245,7 +245,7 @@ describe('AppUsers API', () => {
 
     describe('#uploadImage', () => {
         it('should call http', () => {
-            const fullUrl = api.getFullURL('appUsers', userId, 'images');
+            const fullUrl = `${serviceUrl}/appusers/${userId}/images`;
             const source = createReadStream('some source object');
             const message = {
                 text: 'this is a message'

--- a/test/specs/api/appUsersStripe.spec.js
+++ b/test/specs/api/appUsersStripe.spec.js
@@ -24,7 +24,7 @@ describe('AppUsersStripe API', () => {
     describe('#updateCustomer', () => {
         it('should call http', () => {
             return api.updateCustomer(userId, 'token').then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'stripe', 'customer');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/stripe/customer`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, {
                     token: 'token'
                 }, httpHeaders);
@@ -52,7 +52,7 @@ describe('AppUsersStripe API', () => {
         describe('with token', () => {
             it('should call http', () => {
                 return api.createTransaction(userId, 'actionId', 'token').then(() => {
-                    const fullUrl = api.getFullURL('appUsers', userId, 'stripe', 'transaction');
+                    const fullUrl = `${serviceUrl}/appusers/${userId}/stripe/transaction`;
                     httpSpy.should.have.been.calledWith('POST', fullUrl, {
                         actionId: 'actionId',
                         token: 'token'
@@ -70,7 +70,7 @@ describe('AppUsersStripe API', () => {
         describe('without token', () => {
             it('should call http', () => {
                 return api.createTransaction(userId, 'actionId').then(() => {
-                    const fullUrl = api.getFullURL('appUsers', userId, 'stripe', 'transaction');
+                    const fullUrl = `${serviceUrl}/appusers/${userId}/stripe/transaction`;
                     httpSpy.should.have.been.calledWith('POST', fullUrl, {
                         actionId: 'actionId'
                     }, httpHeaders);

--- a/test/specs/api/appUsersViber.spec.js
+++ b/test/specs/api/appUsersViber.spec.js
@@ -24,7 +24,7 @@ describe('AppUsersViber API', () => {
     describe('#getQRCode', () => {
         it('should call http', () => {
             return api.getQRCode(userId).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'integrations', 'viber', 'qrcode');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/integrations/viber/qrcode`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });

--- a/test/specs/api/appUsersWeChat.spec.js
+++ b/test/specs/api/appUsersWeChat.spec.js
@@ -24,7 +24,7 @@ describe('AppUsersWeChat API', () => {
     describe('#getQRCode', () => {
         it('should call http', () => {
             return api.getQRCode(userId).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'integrations', 'wechat', 'qrcode');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/integrations/wechat/qrcode`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });

--- a/test/specs/api/base.spec.js
+++ b/test/specs/api/base.spec.js
@@ -16,15 +16,6 @@ describe('Base API', () => {
         });
     });
 
-    describe('#getFullURL', () => {
-        const api = new BaseApi(serviceUrl, headers);
-
-        it('should use the serverURL and encode fragments', () => {
-            const finalUrl = api.getFullURL('some', 'u/rl', 'this is an id');
-            finalUrl.should.eql(serviceUrl + '/some/u%2Frl/this%20is%20an%20id');
-        });
-    });
-
     describe('#getHeaders', function() {
         it('should include auth headers and custom headers', () => {
             const api = new BaseApi(serviceUrl, {

--- a/test/specs/api/conversations.spec.js
+++ b/test/specs/api/conversations.spec.js
@@ -25,7 +25,7 @@ describe('Conversations API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(userId).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'conversation');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/conversation`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
@@ -38,7 +38,7 @@ describe('Conversations API', () => {
             };
 
             return api.postPostback(userId, body.actionId).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'conversation', 'postback');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/postback`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, body, httpHeaders);
             });
         });
@@ -72,7 +72,7 @@ describe('Conversations API', () => {
     describe('#resetUnreadCount', () => {
         it('should call http', () => {
             return api.resetUnreadCount(userId).then(() => {
-                const fullUrl = api.getFullURL('appUsers', userId, 'conversation', 'read');
+                const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/read`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, undefined, httpHeaders);
             });
         });

--- a/test/specs/api/menu.spec.js
+++ b/test/specs/api/menu.spec.js
@@ -26,7 +26,7 @@ describe('Menu API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get().then(() => {
-                const fullUrl = api.getFullURL('menu');
+                const fullUrl = `${serviceUrl}/menu`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
@@ -52,7 +52,7 @@ describe('Menu API', () => {
 
         it('should call http', () => {
             return api.configure(props).then(() => {
-                const fullUrl = api.getFullURL('menu');
+                const fullUrl = `${serviceUrl}/menu`;
                 httpSpy.should.have.been.calledWith('PUT', fullUrl, props, httpHeaders);
             });
         });
@@ -88,7 +88,7 @@ describe('Menu API', () => {
     describe('#remove', () => {
         it('should call http', () => {
             return api.remove().then(() => {
-                const fullUrl = api.getFullURL('menu');
+                const fullUrl = `${serviceUrl}/menu`;
                 httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, httpHeaders);
             });
         });

--- a/test/specs/api/stripe.spec.js
+++ b/test/specs/api/stripe.spec.js
@@ -24,7 +24,7 @@ describe('Stripe API', () => {
 
         it('should call http', () => {
             return api.getAccount().then(() => {
-                const fullUrl = api.getFullURL('stripe', 'account');
+                const fullUrl = `${serviceUrl}/stripe/account`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
@@ -37,7 +37,7 @@ describe('Stripe API', () => {
 
             return api.getAccount()
                 .then(() => {
-                    const fullUrl = api.getFullURL('stripe', 'account');
+                    const fullUrl = `${serviceUrl}/stripe/account`;
                     httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
                 });
         });

--- a/test/specs/api/webhooks.spec.js
+++ b/test/specs/api/webhooks.spec.js
@@ -28,8 +28,11 @@ describe('Webhooks API', () => {
     });
 
     describe('#validateProps', () => {
-        it('should return an error if props are not provided', () => {
-            expect(() => api.validateProps()).to.throw(Error, 'incorrect number of parameters');
+        it('should return an error if props are not provided', (done) => {
+            api.validateProps().catch((e) => {
+                e.message.should.equal(noPropsMessage);
+                done();
+            });
         });
 
         it('should return an error if props are empty', (done) => {
@@ -77,7 +80,7 @@ describe('Webhooks API', () => {
     describe('#list', () => {
         it('should call http', () => {
             return api.list().then(() => {
-                const fullUrl = api.getFullURL('webhooks');
+                const fullUrl = `${serviceUrl}/webhooks`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
@@ -97,7 +100,7 @@ describe('Webhooks API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(webhookId).then(() => {
-                const fullUrl = api.getFullURL('webhooks', webhookId);
+                const fullUrl = `${serviceUrl}/webhooks/${webhookId}`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
             });
         });
@@ -122,7 +125,7 @@ describe('Webhooks API', () => {
 
         it('should call http', () => {
             return api.create(props).then(() => {
-                const fullUrl = api.getFullURL('webhooks');
+                const fullUrl = `${serviceUrl}/webhooks`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, props, httpHeaders);
             });
         });
@@ -179,7 +182,7 @@ describe('Webhooks API', () => {
 
         it('should call http', () => {
             return api.update(webhookId, props).then(() => {
-                const fullUrl = api.getFullURL('webhooks', webhookId);
+                const fullUrl = `${serviceUrl}/webhooks/${webhookId}`;
                 httpSpy.should.have.been.calledWith('PUT', fullUrl, props, httpHeaders);
             });
         });
@@ -222,7 +225,7 @@ describe('Webhooks API', () => {
     describe('#delete', () => {
         it('should call http', () => {
             return api.delete(webhookId).then(() => {
-                const fullUrl = api.getFullURL('webhooks', webhookId);
+                const fullUrl = `${serviceUrl}/webhooks/${webhookId}`;
                 httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, httpHeaders);
             });
         });

--- a/test/specs/utils/smoochMethod.spec.js
+++ b/test/specs/utils/smoochMethod.spec.js
@@ -1,5 +1,6 @@
 import { BaseApi } from '../../../src/api/base';
 import smoochMethod from '../../../src/utils/smoochMethod';
+import * as httpMock from '../../mocks/http';
 
 const serviceUrl = 'http://example.org/v1';
 const appId = 'appId';
@@ -24,7 +25,10 @@ Object.assign(TestApi.prototype, {
         params: ['param1'],
         path: '/param1/:param1',
         func: function oneParam(url, param1) {
-            return {url, param1};
+            return {
+                url,
+                param1
+            };
         }
     }),
 
@@ -40,7 +44,12 @@ Object.assign(TestApi.prototype, {
         params: ['param1', 'param2', 'param3'],
         path: '/param1/:param1/param2/:param2/param3/:param3',
         func: function manyParams(url, param1, param2, param3) {
-            return {url, param1, param2, param3};
+            return {
+                url,
+                param1,
+                param2,
+                param3
+            };
         }
     }),
 
@@ -85,6 +94,56 @@ Object.assign(TestApi.prototype, {
         func: function optionalParams(url, param1, param2 = 'default') {
             return [param1, param2];
         }
+    }),
+
+    /**
+     * GET method
+     * @memberof TestApi.prototype
+     * @method getMethod
+     * @param {string} param1 - The first param
+     */
+    getMethod: smoochMethod({
+        params: ['param1'],
+        path: '/param1/:param1',
+        method: 'GET'
+    }),
+
+    /**
+     * POST method
+     * @memberof TestApi.prototype
+     * @method postMethod
+     * @param {string} param1 - The first param
+     * @param {object} props - The props
+     */
+    postMethod: smoochMethod({
+        params: ['param1', 'props'],
+        path: '/param1/:param1',
+        method: 'POST'
+    }),
+
+    /**
+     * PUT method
+     * @memberof TestApi.prototype
+     * @method putMethod
+     * @param {string} param1 - The first param
+     * @param {object} props - The props
+     */
+    putMethod: smoochMethod({
+        params: ['param1', 'props'],
+        path: '/param1/:param1',
+        method: 'PUT'
+    }),
+
+    /**
+     * POST method
+     * @memberof TestApi.prototype
+     * @method deleteMethod
+     * @param {string} param1 - The first param
+     */
+    deleteMethod: smoochMethod({
+        params: ['param1'],
+        path: '/param1/:param1',
+        method: 'DELETE'
     })
 });
 
@@ -246,7 +305,10 @@ describe('Smooch Method', () => {
         });
 
         it('should accept full object', () => {
-            const result = testApi.optionalParams({param1, param2});
+            const result = testApi.optionalParams({
+                param1,
+                param2
+            });
             result.should.deep.equal([param1, param2]);
         });
 
@@ -256,8 +318,51 @@ describe('Smooch Method', () => {
         });
 
         it('should accept only required object', () => {
-            const result = testApi.optionalParams({param1});
+            const result = testApi.optionalParams({
+                param1
+            });
             result.should.deep.equal([param1, 'default']);
+        });
+    });
+
+    describe('simple methods', () => {
+        let httpSpy;
+        let expectedUrl;
+        let body;
+
+        beforeEach(() => {
+            testApi = new TestApi(serviceUrl, {}, {}, false);
+            httpSpy = httpMock.mock();
+            expectedUrl = `${serviceUrl}/param1/${param1}`;
+            body = {
+                'foo': 'bar'
+            };
+        });
+
+        afterEach(() => httpMock.restore());
+
+        it('should make a GET', () => {
+            return testApi.getMethod(param1).then(() => {
+                httpSpy.should.have.been.calledWith('GET', expectedUrl, undefined, {});
+            });
+        });
+
+        it('should make a POST', () => {
+            return testApi.postMethod(param1, body).then(() => {
+                httpSpy.should.have.been.calledWith('POST', expectedUrl, body, {});
+            });
+        });
+
+        it('should make a PUT', () => {
+            return testApi.putMethod(param1, body).then(() => {
+                httpSpy.should.have.been.calledWith('PUT', expectedUrl, body, {});
+            });
+        });
+
+        it('should make a DELETE', () => {
+            return testApi.deleteMethod(param1).then(() => {
+                httpSpy.should.have.been.calledWith('DELETE', expectedUrl, undefined, {});
+            });
         });
     });
 });


### PR DESCRIPTION
I've introduced `path` and `method` options to the `smoochMethod` cookie cutter. The way it works is:

* `path` and `params` are both required
* `path` is a URL path template that will be populated with parms defined in `params`
* A method can then specify either a `func` or a `method` to complete the definition
* A `method` indicates the HTTP verb to be used, in which case `smoochMethod` will simply give you a method that calls `this.request(...)`
* If `method` is `POST` or `PUT`, the last argument will be used as the request payload.
* If the method needs more than that, use `func`. The first arg of `func` will be the full URL to be used. This effectively replaces `base.getFullURL`.
* The path in the `url` used by `smoochMethod` will automatically get prefixed with `/apps/:id` if necessary.