### PR TITLE
Define wrappers for /v1/integration APIs

### DIFF
--- a/src/api/disabled.js
+++ b/src/api/disabled.js
@@ -1,0 +1,15 @@
+export function DisabledApi(message) {
+    this.message = message;
+}
+
+function disabled() {
+    throw new Error(this.message);
+}
+
+Object.assign(DisabledApi.prototype, {
+    create: disabled,
+    list: disabled,
+    get: disabled,
+    delete: disabled
+});
+

--- a/src/api/integrations.js
+++ b/src/api/integrations.js
@@ -33,7 +33,7 @@ const integrations = {
     line: new IntegrationType(['channelAccessToken', 'channelSecret']),
     viber: new IntegrationType(['token']),
     wechat: new IntegrationType(['appId', 'appSecret'], ['encodingAesKey']),
-    email: new IntegrationType([], ['fromAddress'])
+    frontendEmail: new IntegrationType([], ['fromAddress'])
 };
 
 /**
@@ -77,12 +77,19 @@ Object.assign(IntegrationsApi.prototype, {
      * Fetch the integrations currently configured
      * @memberof IntegrationsApi.prototype
      * @method list
+     * @param  {string=} type - Filter results to a specific integration type
      * @return {APIResponse}
      */
     list: smoochMethod({
-        params: [],
+        params: ['type'],
+        optional: ['type'],
         path: '/integrations',
-        method: 'GET'
+        func: function list(url, type) {
+            const q = (type && typeof type === 'string') ? {
+                type
+            } : undefined;
+            return this.request('GET', url, q);
+        }
     }),
 
     /**
@@ -111,4 +118,3 @@ Object.assign(IntegrationsApi.prototype, {
         method: 'DELETE'
     })
 });
-

--- a/src/api/integrations.js
+++ b/src/api/integrations.js
@@ -1,0 +1,114 @@
+import { BaseApi } from './base';
+import smoochMethod from '../utils/smoochMethod';
+
+/**
+ * Init API properties
+ * @typedef IntegrationProps
+ */
+
+function IntegrationType(required, optional = []) {
+    this.required = ['type', ...required];
+    this.optional = optional;
+}
+
+IntegrationType.prototype.validate = function(props) {
+    const missing = this.required.filter((field) => {
+        return !props[field];
+    });
+
+    if (missing.length > 0) {
+        throw new Error(`integration has missing required keys: ${missing.join(', ')}`);
+    }
+
+    const invalid = Object.keys(props).filter((k) => 'string' !== typeof props[k]);
+    if (invalid.length > 0) {
+        throw new Error(`integration has invalid types (expected string): ${invalid.join(', ')}`);
+    }
+};
+
+const integrations = {
+    messenger: new IntegrationType(['pageAccessToken', 'appId', 'appSecret']),
+    twilio: new IntegrationType(['accountSid', 'authToken', 'phoneNumberSid']),
+    telegram: new IntegrationType(['token']),
+    line: new IntegrationType(['channelAccessToken', 'channelSecret']),
+    viber: new IntegrationType(['token']),
+    wechat: new IntegrationType(['appId', 'appSecret'], ['encodingAesKey']),
+    email: new IntegrationType([], ['fromAddress'])
+};
+
+/**
+ * @constructor
+ * @name IntegrationsApi
+ * @extends BaseApi
+ */
+export class IntegrationsApi extends BaseApi {
+    validateProps(props) {
+        if (!props.type) {
+            throw new Error('props missing required field type');
+        }
+
+        const integrationType = integrations[props.type];
+        if (!integrationType) {
+            throw new Error(`Unrecognized type: ${props.type}`);
+        }
+
+        integrationType.validate(props);
+    }
+}
+
+Object.assign(IntegrationsApi.prototype, {
+    /**
+     * Create a new integration
+     * @memberof IntegrationsApi.prototype
+     * @method create
+     * @param  {IntegrationProps} props
+     * @return {APIResponse}
+     */
+    create: smoochMethod({
+        params: ['props'],
+        path: '/integrations',
+        func: function create(url, props) {
+            this.validateProps(props);
+            return this.request('POST', url, props);
+        }
+    }),
+
+    /**
+     * Fetch the integrations currently configured
+     * @memberof IntegrationsApi.prototype
+     * @method list
+     * @return {APIResponse}
+     */
+    list: smoochMethod({
+        params: [],
+        path: '/integrations',
+        method: 'GET'
+    }),
+
+    /**
+     * Retrieve an existing integration
+     * @memberof IntegrationsApi.prototype
+     * @method get
+     * @param  {stirng} integrationId
+     * @return {APIResponse}
+     */
+    get: smoochMethod({
+        params: ['integrationId'],
+        path: '/integrations/:integrationId',
+        method: 'GET'
+    }),
+
+    /**
+     * Delete an existing integration
+     * @memberof IntegrationsApi.prototype
+     * @method delete
+     * @param  {stirng} integrationId
+     * @return {APIResponse}
+     */
+    delete: smoochMethod({
+        params: ['integrationId'],
+        path: '/integrations/:integrationId',
+        method: 'DELETE'
+    })
+});
+

--- a/src/api/integrations.js
+++ b/src/api/integrations.js
@@ -77,18 +77,27 @@ Object.assign(IntegrationsApi.prototype, {
      * Fetch the integrations currently configured
      * @memberof IntegrationsApi.prototype
      * @method list
-     * @param  {string=} type - Filter results to a specific integration type
+     * @param  {(string|string[])=} type - Filter results to a specific integration type
      * @return {APIResponse}
      */
     list: smoochMethod({
-        params: ['type'],
-        optional: ['type'],
+        params: ['types'],
+        optional: ['types'],
         path: '/integrations',
-        func: function list(url, type) {
-            const q = (type && typeof type === 'string') ? {
-                type
-            } : undefined;
-            return this.request('GET', url, q);
+        func: function list(url, types) {
+            const query = {};
+            if (typeof types === 'string') {
+                query.types = types;
+            } else if (types && types.constructor === Array) {
+                query.types = types.filter((t) => typeof t === 'string')
+                    .join(',') || undefined;
+            }
+
+            if (query.types) {
+                return this.request('GET', url, query);
+            } else {
+                return this.request('GET', url);
+            }
         }
     }),
 

--- a/src/api/webhooks.js
+++ b/src/api/webhooks.js
@@ -27,18 +27,16 @@ export class WebhooksApi extends BaseApi {
      */
     validateProps(props, isTargetRequired = false) {
         if (!props || Object.keys(props).length === 0) {
-            return Promise.reject(new Error('Must provide props.'));
+            throw new Error('Must provide props.');
         }
 
         if (isTargetRequired && !props.target) {
-            return Promise.reject(new Error('Must provide a target.'));
+            throw new Error('Must provide a target.');
         }
 
         if (props.target && !props.target.startsWith('http://') && !props.target.startsWith('https://')) {
-            return Promise.reject(new Error('Malformed target url.'));
+            throw new Error('Malformed target url.');
         }
-
-        return Promise.resolve(props);
     }
 }
 
@@ -66,10 +64,8 @@ Object.assign(WebhooksApi.prototype, {
         params: ['props'],
         path: '/webhooks',
         func: function create(url, props) {
-            this.validateProps(props);
-            return this.validateProps(props, true).then((validatedProps) => {
-                return this.request('POST', url, validatedProps);
-            });
+            this.validateProps(props, true);
+            return this.request('POST', url, props);
         }
     }),
 
@@ -98,9 +94,8 @@ Object.assign(WebhooksApi.prototype, {
         params: ['webhookId', 'props'],
         path: '/webhooks/:webhookId',
         func: function update(url, webhookId, props) {
-            return this.validateProps(props).then((validatedProps) => {
-                return this.request('PUT', url, validatedProps);
-            });
+            this.validateProps(props);
+            return this.request('PUT', url, props);
         }
     }),
 

--- a/src/smooch-node.js
+++ b/src/smooch-node.js
@@ -50,9 +50,10 @@ export class Smooch extends SmoochBase {
 
         super(auth, options);
         this.scope = auth.scope || 'appUser';
+        const accountScope = this.scope === 'account';
 
-        this.webhooks = new WebhooksApi(this.serviceUrl, this.authHeaders, this.headers);
-        this.menu = new MenuApi(this.serviceUrl, this.authHeaders, this.headers);
+        this.webhooks = new WebhooksApi(this.serviceUrl, this.authHeaders, this.headers, accountScope);
+        this.menu = new MenuApi(this.serviceUrl, this.authHeaders, this.headers, accountScope);
         if (this.scope === 'account') {
             this.integrations = new IntegrationsApi(this.serviceUrl, this.authHeaders, this.headers, true);
         } else {

--- a/src/smooch-node.js
+++ b/src/smooch-node.js
@@ -1,6 +1,8 @@
 import { Smooch as SmoochBase } from './smooch';
 import { WebhooksApi } from './api/webhooks';
 import { MenuApi } from './api/menu';
+import { IntegrationsApi } from './api/integrations';
+import { DisabledApi } from './api/disabled';
 import * as jwt from './utils/jwt';
 import { decode } from 'jsonwebtoken';
 
@@ -51,6 +53,11 @@ export class Smooch extends SmoochBase {
 
         this.webhooks = new WebhooksApi(this.serviceUrl, this.authHeaders, this.headers);
         this.menu = new MenuApi(this.serviceUrl, this.authHeaders, this.headers);
+        if (this.scope === 'account') {
+            this.integrations = new IntegrationsApi(this.serviceUrl, this.authHeaders, this.headers, true);
+        } else {
+            this.integrations = new DisabledApi('This API requires account level scope');
+        }
 
         Object.assign(this.utils, {
             jwt

--- a/src/utils/smoochMethod.js
+++ b/src/utils/smoochMethod.js
@@ -1,4 +1,18 @@
 export default function smoochMethod({params, optional=[], path, method, func}) {
+    if (!params || !path) {
+        throw new Error('params and path are required');
+    }
+
+    if (!method && !func) {
+        throw new Error('at least one of func or method are required');
+    }
+
+    if (method && func) {
+        throw new Error('func and method are mutually exclusive');
+    }
+
+    const methodName = func ? func.name : `${method} ${path}`;
+
     return function() {
         let args;
         let allParams = params;
@@ -24,7 +38,7 @@ export default function smoochMethod({params, optional=[], path, method, func}) 
                     const value = paramObject[param];
                     const isRequired = requiredParams.includes(param);
                     if (!value && isRequired) {
-                        throw new Error(`${func.name}: missing required argument: ${param}`);
+                        throw new Error(`${methodName}: missing required argument: ${param}`);
                     }
 
                     if (value) {
@@ -37,11 +51,11 @@ export default function smoochMethod({params, optional=[], path, method, func}) 
         }
 
         if (args.length < requiredParams.length) {
-            throw new Error(`${func.name}: incorrect number of parameters (${args.length}). Expected at least ${requiredParams.length}`);
+            throw new Error(`${methodName}: incorrect number of parameters (${args.length}). Expected at least ${requiredParams.length}`);
         }
 
         if (args.length > allParams.length) {
-            throw new Error(`${func.name}: incorrect number of parameters (${args.length}). Expected at most ${params.length}`);
+            throw new Error(`${methodName}: incorrect number of parameters (${args.length}). Expected at most ${params.length}`);
         }
 
         allParams.forEach((param, i) => {

--- a/src/utils/smoochMethod.js
+++ b/src/utils/smoochMethod.js
@@ -15,11 +15,13 @@ export default function smoochMethod({params, optional=[], path, method, func}) 
 
     return function() {
         let args;
-        let allParams = params;
+        let allParams;
         let renderedPath = path;
         if (this.requireAppId) {
             allParams = ['appId', ...params];
             renderedPath = `/apps/:appId${path}`;
+        } else {
+            allParams = [...params];
         }
 
         const requiredParams = allParams.filter((p) => !optional.includes(p));

--- a/test/specs/api/integrations.spec.js
+++ b/test/specs/api/integrations.spec.js
@@ -1,0 +1,241 @@
+import * as httpMock from '../../mocks/http';
+import { getAuthenticationHeaders } from '../../../src/utils/auth';
+import { IntegrationsApi } from '../../../src/api/Integrations';
+import { testJwt } from '../../mocks/jwt';
+
+describe('Integrations API', () => {
+    const serviceUrl = 'http://some-url.com';
+    const webhookId = 'some-id';
+    const webhookUrl = 'http://some-url.com/webhook';
+    const malformedWebhookUrl = 'some-url-missing-http-prefix.com';
+    const invalidAuthErrorMessage = 'Must not use an app token for authentication.';
+    const malformedTargetUrl = 'Malformed target url.';
+    const noPropsMessage = 'Must provide props.';
+    const noTargetMessage = 'Must provide a target.';
+    const missingParams = 'incorrect number of parameters';
+    const httpHeaders = getAuthenticationHeaders({
+        jwt: testJwt()
+    });
+    const appId = 'appid_12345';
+    let httpSpy;
+    let api;
+
+    beforeEach(() => {
+        httpSpy = httpMock.mock();
+        api = new IntegrationsApi(serviceUrl, httpHeaders, null, true);
+    });
+
+    afterEach(() => {
+        httpMock.restore();
+    });
+
+    describe('#create', () => {
+        it('should throw if props are not provided', () => {
+            expect(() => api.create(appId)).to.throw(Error, missingParams);
+        });
+
+        it('should throw if props are empty', () => {
+            expect(() => api.create(appId, {})).to.throw(Error, 'props missing required field type');
+        });
+
+        describe('messenger', () => {
+            it('should throw if missing required params', () => {
+                const invalid = {
+                    type: 'messenger'
+                };
+                expect(() => api.create(appId, invalid)).to.throw(Error, 'integration has missing required keys: pageAccessToken, appId, appSecret');
+            });
+
+            it('should call http', () => {
+                const props = {
+                    type: 'messenger',
+                    pageAccessToken: 'foo',
+                    appId: 'bar',
+                    appSecret: 'baz'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+        });
+
+        describe('twilio', () => {
+            it('should throw if missing required params', () => {
+                const invalid = {
+                    type: 'twilio'
+                };
+                expect(() => api.create(appId, invalid)).to.throw(Error, 'integration has missing required keys: accountSid, authToken, phoneNumberSid');
+            });
+
+            it('should call http', () => {
+                const props = {
+                    type: 'twilio',
+                    accountSid: 'foo',
+                    authToken: 'bar',
+                    phoneNumberSid: 'baz'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+        });
+
+        describe('telegram', () => {
+            it('should throw if missing required params', () => {
+                const invalid = {
+                    type: 'telegram'
+                };
+                expect(() => api.create(appId, invalid)).to.throw(Error, 'integration has missing required keys: token');
+            });
+
+            it('should call http', () => {
+                const props = {
+                    type: 'telegram',
+                    token: 'foo'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+        });
+
+        describe('line', () => {
+            it('should throw if missing required params', () => {
+                const invalid = {
+                    type: 'line'
+                };
+                expect(() => api.create(appId, invalid)).to.throw(Error, 'integration has missing required keys: channelAccessToken, channelSecret');
+            });
+
+            it('should call http', () => {
+                const props = {
+                    type: 'line',
+                    channelAccessToken: 'foo',
+                    channelSecret: 'bar'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+        });
+
+        describe('viber', () => {
+            it('should throw if missing required params', () => {
+                const invalid = {
+                    type: 'viber'
+                };
+                expect(() => api.create(appId, invalid)).to.throw(Error, 'integration has missing required keys: token');
+            });
+
+            it('should call http', () => {
+                const props = {
+                    type: 'viber',
+                    token: 'foo'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+        });
+
+        describe('wechat', () => {
+            it('should throw if missing required params', () => {
+                const invalid = {
+                    type: 'wechat'
+                };
+                expect(() => api.create(appId, invalid)).to.throw(Error, 'integration has missing required keys: appId, appSecret');
+            });
+
+            it('should call http', () => {
+                const props = {
+                    type: 'wechat',
+                    appId: 'foo',
+                    appSecret: 'bar'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+
+            it('should call http with optional props', () => {
+                const props = {
+                    type: 'wechat',
+                    appId: 'foo',
+                    appSecret: 'bar',
+                    encodingAesKey: 'baz'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+        });
+
+        describe('email', () => {
+            it('should call http', () => {
+                const props = {
+                    type: 'email'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+
+            it('should call http with optional props', () => {
+                const props = {
+                    type: 'email',
+                    fromAddress: 'foo'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+        });
+    });
+
+
+    describe('#list', () => {
+        it('should call http', () => {
+            return api.list(appId).then(() => {
+                const url = `${serviceUrl}/apps/${appId}/integrations`;
+                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+            });
+        });
+    });
+
+    describe('#get', () => {
+        it('should call http', () => {
+            const integrationId = 'integration_123456';
+            return api.get(appId, integrationId).then(() => {
+                const url = `${serviceUrl}/apps/${appId}/integrations/${integrationId}`;
+                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+            });
+        });
+
+        it('should throw if missing integrationId', () => {
+            expect(() => api.get(appId)).to.throw(Error, missingParams);
+        });
+    });
+
+    describe('#delete', () => {
+        it('should call http', () => {
+            const integrationId = 'integration_123456';
+            return api.delete(appId, integrationId).then(() => {
+                const url = `${serviceUrl}/apps/${appId}/integrations/${integrationId}`;
+                httpSpy.should.have.been.calledWith('DELETE', url, undefined, httpHeaders);
+            });
+        });
+
+        it('should throw error if missing integrationId', () => {
+            expect(() => api.delete(appId)).to.throw(Error, missingParams);
+        });
+    });
+});

--- a/test/specs/api/integrations.spec.js
+++ b/test/specs/api/integrations.spec.js
@@ -170,10 +170,10 @@ describe('Integrations API', () => {
             });
         });
 
-        describe('email', () => {
+        describe('frontendEmail', () => {
             it('should call http', () => {
                 const props = {
-                    type: 'email'
+                    type: 'frontendEmail'
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
@@ -183,7 +183,7 @@ describe('Integrations API', () => {
 
             it('should call http with optional props', () => {
                 const props = {
-                    type: 'email',
+                    type: 'frontendEmail',
                     fromAddress: 'foo'
                 };
                 return api.create(appId, props).then(() => {
@@ -200,6 +200,14 @@ describe('Integrations API', () => {
             return api.list(appId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/integrations`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+            });
+        });
+
+        it('should accept type query', () => {
+            const type = 'my_type';
+            return api.list(appId, type).then(() => {
+                const url = `${serviceUrl}/apps/${appId}/integrations`;
+                httpSpy.should.have.been.calledWith('GET', url, {type}, httpHeaders);
             });
         });
     });

--- a/test/specs/api/integrations.spec.js
+++ b/test/specs/api/integrations.spec.js
@@ -1,17 +1,10 @@
 import * as httpMock from '../../mocks/http';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
-import { IntegrationsApi } from '../../../src/api/Integrations';
+import { IntegrationsApi } from '../../../src/api/integrations';
 import { testJwt } from '../../mocks/jwt';
 
 describe('Integrations API', () => {
     const serviceUrl = 'http://some-url.com';
-    const webhookId = 'some-id';
-    const webhookUrl = 'http://some-url.com/webhook';
-    const malformedWebhookUrl = 'some-url-missing-http-prefix.com';
-    const invalidAuthErrorMessage = 'Must not use an app token for authentication.';
-    const malformedTargetUrl = 'Malformed target url.';
-    const noPropsMessage = 'Must provide props.';
-    const noTargetMessage = 'Must provide a target.';
     const missingParams = 'incorrect number of parameters';
     const httpHeaders = getAuthenticationHeaders({
         jwt: testJwt()

--- a/test/specs/api/integrations.spec.js
+++ b/test/specs/api/integrations.spec.js
@@ -203,11 +203,19 @@ describe('Integrations API', () => {
             });
         });
 
-        it('should accept type query', () => {
-            const type = 'my_type';
-            return api.list(appId, type).then(() => {
+        it('should accept types string', () => {
+            const types = 'type1,type2';
+            return api.list(appId, types).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/integrations`;
-                httpSpy.should.have.been.calledWith('GET', url, {type}, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, {types}, httpHeaders);
+            });
+        });
+
+        it('should accept types array', () => {
+            const types = ['type1', 'type2'];
+            return api.list(appId, types).then(() => {
+                const url = `${serviceUrl}/apps/${appId}/integrations`;
+                httpSpy.should.have.been.calledWith('GET', url, {types: 'type1,type2'}, httpHeaders);
             });
         });
     });

--- a/test/specs/api/webhooks.spec.js
+++ b/test/specs/api/webhooks.spec.js
@@ -12,6 +12,7 @@ describe('Webhooks API', () => {
     const malformedTargetUrl = 'Malformed target url.';
     const noPropsMessage = 'Must provide props.';
     const noTargetMessage = 'Must provide a target.';
+    const incorrectParamCount = 'incorrect number of parameters';
     const httpHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
@@ -28,51 +29,38 @@ describe('Webhooks API', () => {
     });
 
     describe('#validateProps', () => {
-        it('should return an error if props are not provided', (done) => {
-            api.validateProps().catch((e) => {
-                e.message.should.equal(noPropsMessage);
-                done();
-            });
+        it('should throw an error if props are not provided', () => {
+            expect(() => api.validateProps()).to.throw(Error, noPropsMessage);
         });
 
-        it('should return an error if props are empty', (done) => {
-            api.validateProps({}).catch((e) => {
-                e.message.should.equal(noPropsMessage);
-                done();
-            });
+        it('should throw an error if props are empty', () => {
+            expect(() => api.validateProps({})).to.throw(Error, noPropsMessage);
         });
 
-
-        it('should return an error if target is not provided and required', (done) => {
-            api.validateProps({
+        it('should throw an error if target is not provided and required', () => {
+            expect(() => api.validateProps({
                 event: 'message'
-            }, true).catch((e) => {
-                e.message.should.equal(noTargetMessage);
-                done();
-            });
+            }, true)).to.throw(Error, noTargetMessage);
         });
 
-        it('should not return an error if target is provided and required', () => {
-            return api.validateProps({
+        it('should not throw an error if target is provided and required', () => {
+            expect(() => api.validateProps({
                 target: webhookUrl,
                 event: 'message'
-            }, true);
+            }, true)).to.not.throw;
         });
 
-       it('should return an error if props url target is malformed', (done) => {
-            api.validateProps({
+        it('should throw an error if props url target is malformed', () => {
+            expect(() => api.validateProps({
                 target: malformedWebhookUrl,
                 event: 'message'
-            }).catch((e) => {
-                e.message.should.equal(malformedTargetUrl);
-                done();
-            });
+            })).to.throw(Error, malformedTargetUrl);
         });
 
-        it('should not return an error if props are provided and target is not required', () => {
-            return api.validateProps({
+        it('should not throw an error if props are provided and target is not required', () => {
+            expect(() => api.validateProps({
                 event: 'message'
-            });
+            })).to.not.throw;
         });
 
     });
@@ -130,46 +118,33 @@ describe('Webhooks API', () => {
             });
         });
 
-        it('should return an error if no target', (done) => {
-            api.create({
+        it('should throw an error if no target', () => {
+            expect(() => api.create({
                 event: 'event'
-            }).catch((e) => {
-                e.message.should.equal(noTargetMessage);
-                done();
-            });
+            })).to.throw(Error, noTargetMessage);
         });
 
-        it('should return an error if no props', (done) => {
-            api.create(undefined).catch((e) => {
-                e.message.should.equal(noPropsMessage);
-                done();
-            });
+        it('should throw an error if no props', () => {
+            expect(() => api.create(undefined)).to.throw(Error, noPropsMessage);
         });
 
-        it('should return an error if props are empty', (done) => {
-            api.create({}).catch((e) => {
-                e.message.should.equal(noPropsMessage);
-                done();
-            });
+        it('should throw an error if props are empty', () => {
+            expect(() => api.create({})).to.throw(Error, noPropsMessage);
         });
 
-        it('should return an error if target url is malformed', (done) => {
-            api.create({
+        it('should throw an error if target url is malformed', () => {
+            expect(() => api.create({
                 target: malformedWebhookUrl
-            }).catch((e) => {
-                e.message.should.equal(malformedTargetUrl);
-                done();
-            });
+            })).to.throw(Error, malformedTargetUrl);
         });
 
-        it('should return an error if app token in auth', (done) => {
+        it('should reject if app token in auth', () => {
             const badApi = new WebhooksApi(serviceUrl, getAuthenticationHeaders({
                 appToken: 'some-token'
             }));
 
             badApi.create(props).catch((e) => {
                 e.message.should.equal(invalidAuthErrorMessage);
-                done();
             });
         });
     });
@@ -187,30 +162,21 @@ describe('Webhooks API', () => {
             });
         });
 
-        it('should return an error if no props', (done) => {
-            api.update(webhookId, undefined).catch((e) => {
-                e.message.should.equal(noPropsMessage);
-                done();
-            });
+        it('should throw an error if no props', () => {
+            expect(() => api.update(webhookId, undefined)).to.throw(Error, noPropsMessage);
         });
 
-        it('should return an error if props are empty', (done) => {
-            api.update(webhookId, {}).catch((e) => {
-                e.message.should.equal(noPropsMessage);
-                done();
-            });
+        it('should throw an error if props are empty', () => {
+            expect(() => api.update(webhookId, {})).to.throw(Error, noPropsMessage);
         });
 
-        it('should return an error if target url is malformed', (done) => {
-            api.update(webhookId, {
+        it('should throw an error if target url is malformed', () => {
+            expect(() => api.update(webhookId, {
                 target: malformedWebhookUrl
-            }).catch((e) => {
-                e.message.should.equal(malformedTargetUrl);
-                done();
-            });
+            })).to.throw(Error, malformedTargetUrl);
         });
 
-        it('should return an error if app token in auth', (done) => {
+        it('should reject if app token in auth', (done) => {
             const badApi = new WebhooksApi(serviceUrl, getAuthenticationHeaders({
                 appToken: 'some-token'
             }));

--- a/test/specs/api/webhooks.spec.js
+++ b/test/specs/api/webhooks.spec.js
@@ -12,7 +12,6 @@ describe('Webhooks API', () => {
     const malformedTargetUrl = 'Malformed target url.';
     const noPropsMessage = 'Must provide props.';
     const noTargetMessage = 'Must provide a target.';
-    const incorrectParamCount = 'incorrect number of parameters';
     const httpHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });

--- a/test/specs/wrappers/node.spec.js
+++ b/test/specs/wrappers/node.spec.js
@@ -30,6 +30,17 @@ describe('Smooch', () => {
         smooch.authHeaders.should.deep.equal(headers);
     });
 
+    it('should return disabled APIs without account scope', () => {
+        const authOptions = {
+            jwt: testJwt('app')
+        };
+        const smooch = new Smooch(authOptions);
+        ['create', 'list', 'get', 'delete'].forEach((method) => {
+            expect(() => smooch.integrations[method]())
+                .to.throw(Error, 'This API requires account level scope');
+        });
+    });
+
     ['appUser', 'appMaker', 'integration', 'account'].forEach((scope) => {
         it(`should extract ${scope} scope from a provided jwt`, () => {
             const smooch = new Smooch({


### PR DESCRIPTION
Also introduced a DisabledApi. If an incorrect scope is provided, any calls made to the integration APIs will fail immediately, with a friendlier error message.

Also changed webhook APIs to throw immediately when params fail validation, which means this branch will require a major version bump.