### PR TITLE
Allow more APIs to be used with account scope

### DIFF
--- a/src/smooch-node.js
+++ b/src/smooch-node.js
@@ -4,6 +4,9 @@ import { MenuApi } from './api/menu';
 import { IntegrationsApi } from './api/integrations';
 import { AppsApi } from './api/apps';
 import { AppKeysApi } from './api/apps';
+import { AppUsersApi } from './api/appUsers';
+import { ConversationsApi } from './api/conversations';
+import { StripeApi } from './api/stripe';
 import { DisabledApi } from './api/disabled';
 import * as jwt from './utils/jwt';
 import { decode } from 'jsonwebtoken';
@@ -59,6 +62,9 @@ export class Smooch extends SmoochBase {
         if (this.scope === 'account') {
             this.integrations = new IntegrationsApi(this.serviceUrl, this.authHeaders, this.headers, true);
             this.apps = new AppsApi(this.serviceUrl, this.authHeaders, this.headers, true);
+            this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers, true);
+            this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders, this.headers, true);
+            this.stripe = new StripeApi(this.serviceUrl, this.authHeaders, this.headers, true);
         } else {
             const disabled = new DisabledApi('This API requires account level scope');
             this.integrations = this.apps = disabled;


### PR DESCRIPTION
This PR allows you to use APIs such as `appUsers.sendMessage` with account scope.