### PR TITLE
Add Twitter and mailgun channels, remove frontendEmail channel

### DIFF
--- a/src/api/integrations.js
+++ b/src/api/integrations.js
@@ -57,7 +57,8 @@ const integrations = {
     line: new IntegrationType(['channelAccessToken', 'channelSecret']),
     viber: new IntegrationType(['token']),
     wechat: new IntegrationType(['appId', 'appSecret'], ['encodingAesKey']),
-    frontendEmail: new IntegrationType([], ['fromAddress']),
+    twitter: new IntegrationType(['consumerKey', 'consumerSecret', 'accessTokenKey', 'accessTokenSecret']),
+    mailgun: new IntegrationType(['apiKey', 'domain', 'incomingAddress']),
     fcm: new IntegrationType(['serverKey', 'senderId']),
     apn: new IntegrationType(['certificate'], [{
         name: 'autoUpdateBadge',

--- a/test/specs/api/integrations.spec.js
+++ b/test/specs/api/integrations.spec.js
@@ -53,6 +53,52 @@ describe('Integrations API', () => {
             });
         });
 
+
+        describe('twitter', () => {
+            it('should throw if missing required params', () => {
+                const invalid = {
+                    type: 'twitter'
+                };
+                expect(() => api.create(appId, invalid)).to.throw(Error, 'integration has missing required keys: consumerKey, consumerSecret, accessTokenKey, accessTokenSecret');
+            });
+
+            it('should call http', () => {
+                const props = {
+                    type: 'twitter',
+                    consumerKey: 'foo',
+                    consumerSecret: 'bar',
+                    accessTokenKey: 'baz',
+                    accessTokenSecret: 'schwifty'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+        });
+
+        describe('mailgun', () => {
+            it('should throw if missing required params', () => {
+                const invalid = {
+                    type: 'mailgun'
+                };
+                expect(() => api.create(appId, invalid)).to.throw(Error, 'integration has missing required keys: apiKey, domain, incomingAddress');
+            });
+
+            it('should call http', () => {
+                const props = {
+                    type: 'mailgun',
+                    apiKey: 'foo',
+                    domain: 'bar',
+                    incomingAddress: 'baz'
+                };
+                return api.create(appId, props).then(() => {
+                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                });
+            });
+        });
+
         describe('twilio', () => {
             it('should throw if missing required params', () => {
                 const invalid = {
@@ -245,29 +291,6 @@ describe('Integrations API', () => {
                 }];
 
                 expect(() => api.create(appId, props)).to.throw(Error, `integration has invalid types: ${JSON.stringify(expectedTypes)}`);
-            });
-        });
-
-        describe('frontendEmail', () => {
-            it('should call http', () => {
-                const props = {
-                    type: 'frontendEmail'
-                };
-                return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
-                });
-            });
-
-            it('should call http with optional props', () => {
-                const props = {
-                    type: 'frontendEmail',
-                    fromAddress: 'foo'
-                };
-                return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
-                });
             });
         });
     });


### PR DESCRIPTION
This PR removes the frontendEmail integration from smooch-core and adds mailgun and twitter.