### PR TITLE
Add support for proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ smoochCore.webhooks.get(id).then(function(response) {
 
 ```
 
+#### Usage with a proxy
+If you need to use a proxy, you can use one of the [many](https://www.npmjs.com/package/socks-proxy-agent) [proxies](https://www.npmjs.com/package/http-proxy-agent) [available](https://www.npmjs.com/package/https-proxy-agent), as long as it an `http.Agent` implementation. You only need to pass the agent when creating the SmoochCore instance. 
+
+
+```js
+var SmoochCore = require('smooch-core');
+var SocksProxyAgent = require('socks-proxy-agent');
+var proxy = process.env.http_proxy || 'socks://localhost:8123';
+var agent = new SocksProxyAgent(proxy);
+
+var core = new SmoochCore({
+    keyId: 'some-key',
+    secret: 'some-secret'
+}, {
+  httpAgent: agent
+});
+```
+
 ## API
 
 Below is a list of methods included in Smooch Core. For comprehensive documentation of Smooch Core and its methods see Smooch's [REST API docs](https://docs.smooch.io/rest/).

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -12,11 +12,12 @@ import { http } from '../utils/http';
  * @class BaseApi
  */
 export class BaseApi {
-    constructor(serviceUrl, authHeaders, headers, requireAppId) {
+    constructor(serviceUrl, authHeaders, headers, requireAppId, httpAgent) {
         this.serviceUrl = serviceUrl;
         this.authHeaders = authHeaders;
         this.headers = headers;
         this.requireAppId = !!requireAppId;
+        this.httpAgent = httpAgent;
 
         // both are allowed unless stated otherwise
         this.allowedAuth = ['jwt', 'appToken'];
@@ -57,7 +58,7 @@ export class BaseApi {
     request(method, url, data, {allowedAuth=this.allowedAuth} = {}) {
         return this.validateAuthHeaders(allowedAuth)
             .then(() => {
-                return http(method, url, data, this.getHeaders(), this.agent);
+                return http(method, url, data, this.getHeaders(), this.httpAgent);
             });
     }
 

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -57,7 +57,7 @@ export class BaseApi {
     request(method, url, data, {allowedAuth=this.allowedAuth} = {}) {
         return this.validateAuthHeaders(allowedAuth)
             .then(() => {
-                return http(method, url, data, this.getHeaders());
+                return http(method, url, data, this.getHeaders(), this.agent);
             });
     }
 

--- a/src/smooch-node.js
+++ b/src/smooch-node.js
@@ -3,7 +3,6 @@ import { WebhooksApi } from './api/webhooks';
 import { MenuApi } from './api/menu';
 import { IntegrationsApi } from './api/integrations';
 import { AppsApi } from './api/apps';
-import { AppKeysApi } from './api/apps';
 import { AppUsersApi } from './api/appUsers';
 import { ConversationsApi } from './api/conversations';
 import { StripeApi } from './api/stripe';
@@ -55,16 +54,16 @@ export class Smooch extends SmoochBase {
 
         super(auth, options);
         this.scope = auth.scope || 'appUser';
-        const accountScope = this.scope === 'account';
+        const isAccountScope = this.scope === 'account';
 
-        this.webhooks = new WebhooksApi(this.serviceUrl, this.authHeaders, this.headers, accountScope);
-        this.menu = new MenuApi(this.serviceUrl, this.authHeaders, this.headers, accountScope);
+        this.webhooks = new WebhooksApi(this.serviceUrl, this.authHeaders, this.headers, isAccountScope, this.httpAgent);
+        this.menu = new MenuApi(this.serviceUrl, this.authHeaders, this.headers, isAccountScope, this.httpAgent);
         if (this.scope === 'account') {
-            this.integrations = new IntegrationsApi(this.serviceUrl, this.authHeaders, this.headers, true);
-            this.apps = new AppsApi(this.serviceUrl, this.authHeaders, this.headers, true);
-            this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers, true);
-            this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders, this.headers, true);
-            this.stripe = new StripeApi(this.serviceUrl, this.authHeaders, this.headers, true);
+            this.integrations = new IntegrationsApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
+            this.apps = new AppsApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
+            this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
+            this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
+            this.stripe = new StripeApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
         } else {
             const disabled = new DisabledApi('This API requires account level scope');
             this.integrations = this.apps = disabled;

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -8,7 +8,7 @@ export const SERVICE_URL = 'https://api.smooch.io/v1';
 
 export class Smooch {
     constructor(auth = {}, options = {}) {
-        const {serviceUrl = SERVICE_URL, headers = {}} = options;
+        const {serviceUrl = SERVICE_URL, headers = {}, agent = {}} = options;
         this.VERSION = packageInfo.version;
         this.serviceUrl = serviceUrl;
         this.scope = 'appUser';
@@ -18,6 +18,7 @@ export class Smooch {
         }
 
         this.headers = headers;
+        this.agent = agent;
         this.authHeaders = getAuthenticationHeaders(auth);
 
         this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers);

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -8,7 +8,7 @@ export const SERVICE_URL = 'https://api.smooch.io/v1';
 
 export class Smooch {
     constructor(auth = {}, options = {}) {
-        const {serviceUrl = SERVICE_URL, headers = {}, agent = {}} = options;
+        const {serviceUrl = SERVICE_URL, headers = {}, httpAgent} = options;
         this.VERSION = packageInfo.version;
         this.serviceUrl = serviceUrl;
         this.scope = 'appUser';
@@ -18,12 +18,12 @@ export class Smooch {
         }
 
         this.headers = headers;
-        this.agent = agent;
+        this.httpAgent = httpAgent;
         this.authHeaders = getAuthenticationHeaders(auth);
 
-        this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers);
-        this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders, this.headers);
-        this.stripe = new StripeApi(this.serviceUrl, this.authHeaders, this.headers);
+        this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers, false, this.httpAgent);
+        this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders, false, this.headers, this.httpAgent);
+        this.stripe = new StripeApi(this.serviceUrl, this.authHeaders, this.headers, false, this.httpAgent);
 
         this.utils = {};
     }

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -61,11 +61,12 @@ export function handleResponse(response) {
     }
 }
 
-export function http(method, url, data, headers = {}) {
+export function http(method, url, data, headers = {}, agent = {}) {
     method = method.toUpperCase();
 
     const fetchOptions = {
         method: method,
+        agent: agent,
         headers: Object.assign({
             'Accept': 'application/json',
             'Content-Type': 'application/json'

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -62,17 +62,19 @@ export function handleResponse(response) {
 }
 
 export function http(method, url, data, headers = {}, agent) {
-    console.log('AGENT', agent)
     method = method.toUpperCase();
 
     const fetchOptions = {
         method: method,
-        agent,
         headers: Object.assign({
             'Accept': 'application/json',
             'Content-Type': 'application/json'
         }, headers)
     };
+
+    if (agent) {
+        fetchOptions.agent = agent;
+    }
 
     if (data) {
         if (data instanceof FormData) {

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -61,12 +61,13 @@ export function handleResponse(response) {
     }
 }
 
-export function http(method, url, data, headers = {}, agent = {}) {
+export function http(method, url, data, headers = {}, agent) {
+    console.log('AGENT', agent)
     method = method.toUpperCase();
 
     const fetchOptions = {
         method: method,
-        agent: agent,
+        agent,
         headers: Object.assign({
             'Accept': 'application/json',
             'Content-Type': 'application/json'

--- a/test/specs/utils/http.spec.js
+++ b/test/specs/utils/http.spec.js
@@ -11,7 +11,7 @@ function getMockedHeaders(headers = {}) {
     };
 }
 
-function generateExpectation(method, url, data, headers) {
+function generateExpectation(method, url, data, headers, agent) {
     method = method.toUpperCase();
 
     const options = {
@@ -21,6 +21,10 @@ function generateExpectation(method, url, data, headers) {
             'Content-Type': 'application/json'
         }, headers)
     };
+
+    if (agent) {
+        options.agent = agent;
+    }
 
     if (data) {
         data = Object.assign({}, data);
@@ -38,11 +42,12 @@ function generateExpectation(method, url, data, headers) {
     };
 }
 
-function generateTestName(method, data, headers) {
+function generateTestName(method, data, headers, agent) {
     const dataPart = data && Object.keys(data).length > 0 ? 'with data' : 'without data';
     const headersPart = headers && Object.keys(headers).length > 0 ? 'with headers' : 'without headers';
+    const agentPart = agent ? 'with headers' : 'without headers';
 
-    return `${method} ${dataPart}, ${headersPart}`;
+    return `${method} ${dataPart}, ${headersPart}, ${agentPart}`;
 }
 
 describe('HTTP', () => {
@@ -67,6 +72,11 @@ describe('HTTP', () => {
             },
             {
                 url: 'http://some-url.com',
+                method: 'GET',
+                agent: 'yes'
+            },
+            {
+                url: 'http://some-url.com',
                 method: 'post',
                 data: {
                     some: 'data'
@@ -81,10 +91,26 @@ describe('HTTP', () => {
             },
             {
                 url: 'http://some-url.com',
+                method: 'POST',
+                data: {
+                    some: 'data'
+                },
+                agent: 'yes'
+            },
+            {
+                url: 'http://some-url.com',
                 method: 'DELETE',
                 data: {
                     some: 'data'
                 }
+            },
+            {
+                url: 'http://some-url.com',
+                method: 'DELETE',
+                data: {
+                    some: 'data'
+                },
+                agent: 'yes'
             },
             {
                 url: 'http://some-url.com',
@@ -98,17 +124,36 @@ describe('HTTP', () => {
             },
             {
                 url: 'http://some-url.com',
+                method: 'POST',
+                data: {
+                    some: 'data'
+                },
+                headers: {
+                    header: 'yes'
+                },
+                agent: 'yes'
+            },
+            {
+                url: 'http://some-url.com',
                 method: 'PUT',
                 headers: {
                     header: 'yes'
                 }
+            },
+            {
+                url: 'http://some-url.com',
+                method: 'PUT',
+                headers: {
+                    header: 'yes'
+                },
+                agent: 'yes'
             }
         ].forEach((options) => {
-            describe(generateTestName(options.method, options.data, options.headers), () => {
+            describe(generateTestName(options.method, options.data, options.headers, options.agent), () => {
                 it('should transform the options correctly', () => {
-                    const expection = generateExpectation(options.method, options.url, options.data, options.headers);
+                    const expection = generateExpectation(options.method, options.url, options.data, options.headers, options.agent);
 
-                    return http(options.method, options.url, options.data, options.headers).then(() => {
+                    return http(options.method, options.url, options.data, options.headers, options.agent).then(() => {
                         fetchSpy.should.have.been.calledWith(expection.url, expection.options);
                     });
                 });


### PR DESCRIPTION
These changes brings support for using a proxy when using it in the backend. The user is responsible to instantiate the proxy agent and pass it to the lib. I added an example in the README.