### PR TITLE
Remove track API

### DIFF
--- a/src/api/appUsers.js
+++ b/src/api/appUsers.js
@@ -97,27 +97,6 @@ Object.assign(AppUsersApi.prototype, {
     }),
 
     /**
-     * Track an event for an app user
-     * @memberof AppUsersApi.prototype
-     * @method trackEvent
-     * @param  {string} userId    - a user id
-     * @param  {string} eventName - the name of the event to track
-     * @param  {object=} props    - props to update before tracking the event
-     * @return {APIResponse}
-     */
-    trackEvent: smoochMethod({
-        params: ['userId', 'eventName', 'props'],
-        optional: ['props'],
-        path: '/appusers/:userId/events',
-        func: function trackEvent(url, userId, eventName, props = {}) {
-            return this.request('POST', url, {
-                name: eventName,
-                appUser: props
-            });
-        }
-    }),
-
-    /**
      * Update the push notification token for a given app user's device
      * @memberof AppUsersApi.prototype
      * @method updatePushToken

--- a/test/specs/api/appUsers.spec.js
+++ b/test/specs/api/appUsers.spec.js
@@ -105,23 +105,6 @@ describe('AppUsers API', () => {
         });
     });
 
-    describe('#trackEvent', () => {
-        it('should call http', () => {
-            const eventName = 'some-event';
-            const props = {
-                email: 'this is an email'
-            };
-
-            return api.trackEvent(userId, eventName, props).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/events`;
-                httpSpy.should.have.been.calledWith('POST', fullUrl, {
-                    name: eventName,
-                    appUser: props
-                }, httpHeaders);
-            });
-        });
-    });
-
     describe('#updatePushToken', () => {
         it('should call http', () => {
             const deviceId = 'device-id';


### PR DESCRIPTION
As whispers are being deprecated, this endpoint doesn't make sense anymore. For people who need it until October, they can always use a previous version of the lib or call the API manually.