### PR TITLE
Replaced node-fetch with isomorphic-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "form-data": "0.2.0",
-    "jsonwebtoken": "5.4.1",
-    "node-fetch": "1.7.2"
+    "isomorphic-fetch": "2.2.1",
+    "jsonwebtoken": "5.4.1"
   }
 }

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const fetch = require('isomorphic-fetch');
 
 /**
  * API Response promise - resolves with the requested resource


### PR DESCRIPTION
Since the library is meant to be used both in servers and in clients environments using the isomorphic-fetch is semantically better; 
Moreover in few clients (like cordova applications) node-fetch fails in many places for example when using zlib to compress/decompress the data.