### PR TITLE
Add support for service accounts API

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ Below is a list of methods included in Smooch Core. For comprehensive documentat
 |              | create             | [POST /v1/webhooks](https://docs.smooch.io/rest/?javascript#create-webhook) |
 |              | get                | [GET /v1/webhooks/:id](https://docs.smooch.io/rest/?javascript#get-webhook) |
 |              | update             | [PUT /v1/webhooks/:id](https://docs.smooch.io/rest/?javascript#update-webhook) |
-|              | delete             | [DELETE /v1/webhooks/:id](https://docs.smooch.io/rest/?javascript#dlete-webhook) |
+|              | delete             | [DELETE /v1/webhooks/:id](https://docs.smooch.io/rest/?javascript#delete-webhook) |
 | apps         | create             | [POST /v1/apps](https://docs.smooch.io/rest/?javascript#create-app) |
 |              | list               | [GET /v1/apps](https://docs.smooch.io/rest/?javascript#list-apps) |
 |              | get                | [GET /v1/apps/:id](https://docs.smooch.io/rest/?javascript#get-app) |
 |              | delete             | [DELETE /v1/apps/:id](https://docs.smooch.io/rest/?javascript#delete-app) |
-|              | keys.create        | [POST /v1/apps/:id/keys](https://docs.smooch.io/rest/?javascript#create-key) |
-|              | keys.list          | [GET /v1/apps/:id/keys](https://docs.smooch.io/rest/?javascript#list-keys) |
-|              | keys.get           | [GET /v1/apps/:id/keys/:keyId](https://docs.smooch.io/rest/?javascript#get-key) |
-|              | keys.delete        | [DELETE /v1/apps/:id/:keyId](https://docs.smooch.io/rest/?javascript#delete-key) |
-|              | keys.getJwt        | [GET /v1/apps/:id/keys/:keyId/jwt](https://docs.smooch.io/rest/?javascript#get-jwt) |
+|              | keys.create        | [POST /v1/apps/:id/keys](https://docs.smooch.io/rest/?javascript#create-app-key) |
+|              | keys.list          | [GET /v1/apps/:id/keys](https://docs.smooch.io/rest/?javascript#list-app-keys) |
+|              | keys.get           | [GET /v1/apps/:id/keys/:keyId](https://docs.smooch.io/rest/?javascript#get-app-key) |
+|              | keys.delete        | [DELETE /v1/apps/:id/:keyId](https://docs.smooch.io/rest/?javascript#delete-app-key) |
+|              | keys.getJwt        | [GET /v1/apps/:id/keys/:keyId/jwt](https://docs.smooch.io/rest/?javascript#get-app-jwt) |
 | integrations | create             | [POST /v1/apps/:id/integrations](https://docs.smooch.io/rest/?javascript#create-integration) |
 |              | list               | [GET /v1/apps/:id/integrations](https://docs.smooch.io/rest/?javascript#list-integrations) |
 |              | get                | [GET /v1/apps/:id/integrations/integrationId](https://docs.smooch.io/rest/?javascript#get-integration) |
@@ -105,6 +105,15 @@ Below is a list of methods included in Smooch Core. For comprehensive documentat
 |              | menu.create        | [POST /v1/apps/:id/integrations/:integrationId/menu](https://docs.smooch.io/rest/?javascript#create-integration-menu) |
 |              | menu.update        | [PUT /v1/apps/:id/integrations/:integrationId/menu](https://docs.smooch.io/rest/?javascript#update-integration-menu) |
 |              | menu.delete        | [DELETE /v1/apps/:id/integrations/:integrationId/menu](https://docs.smooch.io/rest/?javascript#delete-integration-menu) |
+| serviceAccounts  | create             | [POST /v1/serviceaccounts](https://docs.smooch.io/rest/?javascript#create-service-account) |
+|              | list               | [GET /v1/serviceaccounts](https://docs.smooch.io/rest/?javascript#list-service-accounts) |
+|              | get                | [GET /v1/serviceaccounts/:id](https://docs.smooch.io/rest/?javascript#get-service-account) |
+|              | delete             | [DELETE /v1/serviceaccounts/:id](https://docs.smooch.io/rest/?javascript#delete-service-account) |
+|              | keys.create        | [POST /v1/serviceaccounts/:id/keys](https://docs.smooch.io/rest/?javascript#create-service-account-key) |
+|              | keys.list          | [GET /v1/serviceaccounts/:id/keys](https://docs.smooch.io/rest/?javascript#list-service-account-keys) |
+|              | keys.get           | [GET /v1/serviceaccounts/:id/keys/:keyId](https://docs.smooch.io/rest/?javascript#get-service-account-key) |
+|              | keys.delete        | [DELETE /v1/serviceaccounts/:id/:keyId](https://docs.smooch.io/rest/?javascript#delete-service-account-key) |
+|              | keys.getJwt        | [GET /v1/serviceaccounts/:id/keys/:keyId/jwt](https://docs.smooch.io/rest/?javascript#get-service-account-jwt) |
 | attachments  | create             | [POST /v1/apps/:id/attachments](https://docs.smooch.io/rest/?javascript#upload-attachment) |
 
 ## Release process

--- a/src/api/appKeys.js
+++ b/src/api/appKeys.js
@@ -28,7 +28,9 @@ Object.assign(AppKeysApi.prototype, {
             if (typeof name !== 'string') {
                 throw new Error('Invalid name parameter type, expected string');
             }
-            return this.request('POST', url, {name});
+            return this.request('POST', url, {
+                name
+            });
         }
     }),
 
@@ -79,6 +81,7 @@ Object.assign(AppKeysApi.prototype, {
      */
     delete: smoochMethod({
         params: ['keyId'],
-        path: '/keys/:keyId', method: 'DELETE'
+        path: '/keys/:keyId',
+        method: 'DELETE'
     })
 });

--- a/src/api/appKeys.js
+++ b/src/api/appKeys.js
@@ -71,7 +71,7 @@ Object.assign(AppKeysApi.prototype, {
     }),
 
     /**
-     * Delete an existing app
+     * Delete an existing app key
      * @memberof AppKeysApi.prototype
      * @method delete
      * @param  {string} keyId

--- a/src/api/apps.js
+++ b/src/api/apps.js
@@ -52,13 +52,14 @@ Object.assign(AppsApi.prototype, {
      * @method list
      * @param  {number} limit
      * @param  {number} offset
+     * @param  {string} serviceAccountId
      * @return {APIResponse}
      */
     list: smoochMethod({
-        params: ['limit', 'offset'],
-        optional: ['limit', 'offset'],
+        params: ['limit', 'offset', 'serviceAccountId'],
+        optional: ['limit', 'offset', 'serviceAccountId'],
         path: '/apps',
-        func: function list(url, limit, offset) {
+        func: function list(url, limit, offset, serviceAccountId) {
             const q = {};
             if (limit) {
                 if (typeof limit !== 'number') {
@@ -72,8 +73,14 @@ Object.assign(AppsApi.prototype, {
                 }
                 q.offset = offset;
             }
+            if (serviceAccountId) {
+                if (typeof serviceAccountId !== 'string') {
+                    throw new Error('serviceAccountId must be a string');
+                }
+                q.serviceAccountId = serviceAccountId;
+            }
 
-            if (q.limit || q.offset) {
+            if (q.limit || q.offset || q.serviceAccountId) {
                 return this.request('GET', url, q);
             } else {
                 return this.request('GET', url);

--- a/src/api/serviceAccountKeys.js
+++ b/src/api/serviceAccountKeys.js
@@ -1,0 +1,88 @@
+import { BaseApi } from './base';
+import smoochMethod from '../utils/smoochMethod';
+
+/**
+ * @constructor
+ * @name ServiceAccountKeysApi
+ * @extends BaseApi
+ */
+export class ServiceAccountKeysApi extends BaseApi {
+    constructor() {
+        super(...arguments);
+
+        this.requireAppId = false;
+        this.allowedAuth = ['jwt'];
+    }
+}
+
+Object.assign(ServiceAccountKeysApi.prototype, {
+    /**
+     * Create a new service account key
+     * @memberof ServiceAccountKeysApi.prototype
+     * @method create
+     * @param  {string} name
+     * @return {APIResponse}
+     */
+    create: smoochMethod({
+        params: ['serviceAccountId', 'name'],
+        path: '/serviceaccounts/:serviceAccountId/keys',
+        func: function create(url, serviceAccountId, name) {
+            if (typeof name !== 'string') {
+                throw new Error('Invalid name parameter type, expected string');
+            }
+            return this.request('POST', url, {
+                name
+            });
+        }
+    }),
+
+    /**
+     * Fetch the keys currently configured for a service account
+     * @memberof ServiceAccountKeysApi.prototype
+     * @method list
+     * @return {APIResponse}
+     */
+    list: smoochMethod({
+        params: ['serviceAccountId'],
+        path: '/serviceaccounts/:serviceAccountId/keys',
+        method: 'GET'
+    }),
+
+    /**
+     * Retrieve an existing service account key
+     * @memberof ServiceAccountKeysApi.prototype
+     * @method get
+     * @param  {string} keyId
+     * @return {APIResponse}
+     */
+    get: smoochMethod({
+        params: ['serviceAccountId', 'keyId'],
+        path: '/serviceaccounts/:serviceAccountId/keys/:keyId',
+        method: 'GET'
+    }),
+
+    /**
+     * Generate a JWT with account scope using the specified key
+     * @memberof ServiceAccountKeysApi.prototype
+     * @method getJwt
+     * @param  {string} keyId
+     * @return {APIResponse}
+     */
+    getJwt: smoochMethod({
+        params: ['serviceAccountId', 'keyId'],
+        path: '/serviceaccounts/:serviceAccountId/keys/:keyId/jwt',
+        method: 'GET'
+    }),
+
+    /**
+     * Delete an existing service account key
+     * @memberof ServiceAccountKeysApi.prototype
+     * @method delete
+     * @param  {string} keyId
+     * @return {APIResponse}
+     */
+    delete: smoochMethod({
+        params: ['serviceAccountId', 'keyId'],
+        path: '/serviceaccounts/:serviceAccountId/keys/:keyId', method: 'DELETE'
+    })
+});

--- a/src/api/serviceAccountKeys.js
+++ b/src/api/serviceAccountKeys.js
@@ -83,6 +83,7 @@ Object.assign(ServiceAccountKeysApi.prototype, {
      */
     delete: smoochMethod({
         params: ['serviceAccountId', 'keyId'],
-        path: '/serviceaccounts/:serviceAccountId/keys/:keyId', method: 'DELETE'
+        path: '/serviceaccounts/:serviceAccountId/keys/:keyId',
+        method: 'DELETE'
     })
 });

--- a/src/api/serviceAccounts.js
+++ b/src/api/serviceAccounts.js
@@ -1,0 +1,115 @@
+import { BaseApi } from './base';
+import { ServiceAccountKeysApi } from './serviceAccountKeys';
+import smoochMethod from '../utils/smoochMethod';
+
+/**
+ * @constructor
+ * @name ServiceAccountsApi
+ * @extends BaseApi
+ */
+export class ServiceAccountsApi extends BaseApi {
+    constructor() {
+        super(...arguments);
+        this.requireAppId = false;
+        this.allowedAuth = ['jwt'];
+
+        this.keys = new ServiceAccountKeysApi(...arguments);
+    }
+}
+
+Object.assign(ServiceAccountsApi.prototype, {
+    /**
+     * Create a new service account
+     * @memberof ServiceAccountsApi.prototype
+     * @method create
+     * @param  {object} data
+     * @return {APIResponse}
+     */
+    create: smoochMethod({
+        params: ['name'],
+        path: '/serviceaccounts',
+        func: function create(url, name) {
+            if (typeof name !== 'string') {
+                throw new Error('Invalid name parameter type, expected string');
+            }
+
+            return this.request('POST', url, {
+                name
+            });
+        }
+    }),
+
+    /**
+     * Fetch the service accounts currently configured
+     * @memberof ServiceAccountsApi.prototype
+     * @method list
+     * @param  {number} limit
+     * @param  {number} offset
+     * @return {APIResponse}
+     */
+    list: smoochMethod({
+        params: ['limit', 'offset'],
+        optional: ['limit', 'offset'],
+        path: '/serviceaccounts',
+        func: function list(url, limit, offset) {
+            const q = {};
+            if (limit) {
+                if (typeof limit !== 'number') {
+                    throw new Error('limit must be a number');
+                }
+                q.limit = limit;
+            }
+            if (offset) {
+                if (typeof offset !== 'number') {
+                    throw new Error('offset must be a number');
+                }
+                q.offset = offset;
+            }
+
+            if (q.limit || q.offset) {
+                return this.request('GET', url, q);
+            } else {
+                return this.request('GET', url);
+            }
+        }
+    }),
+
+    /**
+     * Retrieve an existing service account
+     * @memberof ServiceAccountsApi.prototype
+     * @method get
+     * @param  {string} serviceAccountId
+     * @return {APIResponse}
+     */
+    get: smoochMethod({
+        params: ['serviceAccountId'],
+        path: '/serviceaccounts/:serviceAccountId',
+        method: 'GET'
+    }),
+
+    /**
+     * Update an existing service account
+     * @memberof ServiceAccountsApi.prototype
+     * @method put
+     * @param  {string} serviceAccountId
+     * @return {APIResponse}
+     */
+    update: smoochMethod({
+        params: ['serviceAccountId', 'data'],
+        path: '/serviceaccounts/:serviceAccountId',
+        method: 'PUT'
+    }),
+
+    /**
+     * Delete an existing service account
+     * @memberof ServiceAccountsApi.prototype
+     * @method delete
+     * @param  {string} serviceAccountId
+     * @return {APIResponse}
+     */
+    delete: smoochMethod({
+        params: ['serviceAccountId'],
+        path: '/serviceaccounts/:serviceAccountId',
+        method: 'DELETE'
+    })
+});

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -7,6 +7,7 @@ import { WebhooksApi } from './api/webhooks';
 import { AttachmentsApi } from './api/attachments';
 import { IntegrationsApi } from './api/integrations';
 import { ConversationsApi } from './api/conversations';
+import { ServiceAccountsApi } from './api/serviceAccounts';
 
 import { getAuthenticationHeaders } from './utils/auth';
 
@@ -89,6 +90,7 @@ class Smooch {
             this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
             this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
             this.stripe = new StripeApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
+            this.serviceAccounts = new ServiceAccountsApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
         } else {
             const disabled = new DisabledApi('This API requires account level scope');
             this.integrations = this.apps = disabled;

--- a/src/utils/smoochMethod.js
+++ b/src/utils/smoochMethod.js
@@ -43,9 +43,7 @@ export default function smoochMethod({params, optional=[], path, method, func}) 
                         throw new Error(`${methodName}: missing required argument: ${param}`);
                     }
 
-                    if (value) {
-                        args.push(value);
-                    }
+                    args.push(value);
                 });
             }
         } else {

--- a/test/specs/api/serviceAccountKeys.spec.js
+++ b/test/specs/api/serviceAccountKeys.spec.js
@@ -1,0 +1,95 @@
+import hat from 'hat';
+
+import * as httpMock from '../../mocks/http';
+import { getAuthenticationHeaders } from '../../../src/utils/auth';
+import { ServiceAccountKeysApi } from '../../../src/api/serviceAccountKeys';
+import { testJwt } from '../../mocks/jwt';
+
+describe('App Keys API', () => {
+    const serviceUrl = 'http://some-url.com';
+    const missingParams = 'incorrect number of parameters';
+    const httpHeaders = getAuthenticationHeaders({
+        jwt: testJwt()
+    });
+    const serviceAccountId = hat();
+    const keyId = hat();
+    let httpSpy;
+    let api;
+
+    beforeEach(() => {
+        httpSpy = httpMock.mock();
+        api = new ServiceAccountKeysApi(serviceUrl, httpHeaders, null, true);
+    });
+
+    afterEach(() => {
+        httpMock.restore();
+    });
+
+    describe('#create', () => {
+        it('should throw if name not provided', () => {
+            expect(() => api.create(serviceAccountId)).to.throw(Error, missingParams);
+        });
+
+        it('should throw if param is wrong type', () => {
+            expect(() => api.create(serviceAccountId, {})).to.throw(Error);
+        });
+
+        it('should call http', () => {
+            const keyName = hat();
+            return api.create(serviceAccountId, keyName).then(() => {
+                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys`;
+                httpSpy.should.have.been.calledWith('POST', url, {
+                    name: keyName
+                }, httpHeaders);
+            });
+        });
+    });
+
+    describe('#list', () => {
+        it('should call http', () => {
+            return api.list(serviceAccountId).then(() => {
+                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys`;
+                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+            });
+        });
+    });
+
+    describe('#get', () => {
+        it('should call http', () => {
+            return api.get(serviceAccountId, keyId).then(() => {
+                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys/${keyId}`;
+                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+            });
+        });
+
+        it('should throw if missing keyId', () => {
+            expect(() => api.get(serviceAccountId)).to.throw(Error, missingParams);
+        });
+    });
+
+    describe('#getJwt', () => {
+        it('should call http', () => {
+            return api.getJwt(serviceAccountId, keyId).then(() => {
+                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys/${keyId}/jwt`;
+                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+            });
+        });
+
+        it('should throw if missing keyId', () => {
+            expect(() => api.getJwt(serviceAccountId)).to.throw(Error, missingParams);
+        });
+    });
+
+    describe('#delete', () => {
+        it('should call http', () => {
+            return api.delete(serviceAccountId, keyId).then(() => {
+                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys/${keyId}`;
+                httpSpy.should.have.been.calledWith('DELETE', url, undefined, httpHeaders);
+            });
+        });
+
+        it('should throw error if missing keyId', () => {
+            expect(() => api.delete(serviceAccountId)).to.throw(Error, missingParams);
+        });
+    });
+});

--- a/test/specs/api/serviceAccounts.spec.js
+++ b/test/specs/api/serviceAccounts.spec.js
@@ -2,23 +2,23 @@ import hat from 'hat';
 
 import * as httpMock from '../../mocks/http';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
-import { AppsApi } from '../../../src/api/apps';
+import { ServiceAccountsApi } from '../../../src/api/serviceAccounts';
 import { testJwt } from '../../mocks/jwt';
 
-describe('Apps API', () => {
+describe('Service Accounts API', () => {
     const serviceUrl = 'http://some-url.com';
     const missingParams = 'incorrect number of parameters';
     const httpHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
-    const appId = 'appid_12345';
-    const appName = 'My Awesome Unit Test App';
+    const serviceAccountId = hat();
+    const serviceAccountName = hat();
     let httpSpy;
     let api;
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new AppsApi(serviceUrl, httpHeaders, null, false);
+        api = new ServiceAccountsApi(serviceUrl, httpHeaders, null, false);
     });
 
     afterEach(() => {
@@ -35,23 +35,21 @@ describe('Apps API', () => {
         });
 
         it('should call http', () => {
-            return api.create(appName).then(() => {
-                const url = `${serviceUrl}/apps`;
+            return api.create(serviceAccountName).then(() => {
+                const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('POST', url, {
-                    name: appName
+                    name: serviceAccountName
                 }, httpHeaders);
             });
         });
 
         it('should call http', () => {
             return api.create({
-                name: appName,
-                settings: {}
+                name: serviceAccountName
             }).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('POST', url, {
-                    name: appName,
-                    settings: {}
+                    name: serviceAccountName
                 }, httpHeaders);
             });
         });
@@ -62,14 +60,14 @@ describe('Apps API', () => {
         const offset = 99;
         it('should call http with no limit or offset', () => {
             return api.list().then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
             });
         });
 
         it('should use limit', () => {
             return api.list(limit).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit
                 }, httpHeaders);
@@ -78,7 +76,7 @@ describe('Apps API', () => {
 
         it('should use offset', () => {
             return api.list(undefined, offset).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     offset
                 }, httpHeaders);
@@ -87,7 +85,7 @@ describe('Apps API', () => {
 
         it('should use both', () => {
             return api.list(limit, offset).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit,
                     offset
@@ -95,98 +93,52 @@ describe('Apps API', () => {
             });
         });
 
-        it('should use serviceAccountId', () => {
-            const serviceAccountId = hat();
-            return api.list(undefined, undefined, serviceAccountId).then(() => {
-                const url = `${serviceUrl}/apps`;
-                httpSpy.should.have.been.calledWith('GET', url, {
-                    serviceAccountId
-                }, httpHeaders);
-            });
-        });
-
-        it('should use all three', () => {
-            const serviceAccountId = hat();
-            return api.list(limit, offset, serviceAccountId).then(() => {
-                const url = `${serviceUrl}/apps`;
-                httpSpy.should.have.been.calledWith('GET', url, {
-                    limit,
-                    offset,
-                    serviceAccountId
-                }, httpHeaders);
-            });
-        });
-
-        it('should allow params object with only serviceAccountId', () => {
-            const serviceAccountId = hat();
-            
-            return api.list({
-                serviceAccountId
-            }).then(() => {
-                const url = `${serviceUrl}/apps`;
-                httpSpy.should.have.been.calledWith('GET', url, {
-                    serviceAccountId
-                }, httpHeaders);
-            });
-        });
-
-        it('should reject non-number limit and offset', () => {
+        it('should reject non-number', () => {
             [['banana'], ['apple', true], [undefined, {}]].forEach((invalid) => {
                 expect(() => api.list(...invalid)).to.throw(Error, 'must be a number');
-            });
-        });
-
-        it('should reject non-string serviceAccountId', () => {
-            [1, true, {}].forEach((invalid) => {
-                expect(() => api.list(undefined, undefined, invalid)).to.throw(Error, 'must be a string');
             });
         });
     });
 
     describe('#get', () => {
         it('should call http', () => {
-            return api.get(appId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}`;
+            return api.get(serviceAccountId).then(() => {
+                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
             });
         });
 
-        it('should throw if missing appId', () => {
+        it('should throw if missing serviceAccountId', () => {
             expect(() => api.get()).to.throw(Error, missingParams);
         });
     });
 
     describe('#put', () => {
         it('should call http', () => {
-            const appId = 'app_123456';
-
-            return api.update(appId, {
-                name: appName,
-                settings: {}
+            return api.update(serviceAccountId, {
+                name: serviceAccountName
             }).then(() => {
-                const url = `${serviceUrl}/apps/${appId}`;
+                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}`;
                 httpSpy.should.have.been.calledWith('PUT', url, {
-                    name: appName,
-                    settings: {}
+                    name: serviceAccountName
                 }, httpHeaders);
             });
         });
 
-        it('should throw if missing appId', () => {
+        it('should throw if missing serviceAccountId', () => {
             expect(() => api.update()).to.throw(Error, missingParams);
         });
     });
 
     describe('#delete', () => {
         it('should call http', () => {
-            const appId = 'app_123456';
-            return api.delete(appId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}`;
+            return api.delete(serviceAccountId).then(() => {
+                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}`;
                 httpSpy.should.have.been.calledWith('DELETE', url, undefined, httpHeaders);
             });
         });
 
-        it('should throw error if missing appId', () => {
+        it('should throw error if missing serviceAccountId', () => {
             expect(() => api.delete()).to.throw(Error, missingParams);
         });
     });


### PR DESCRIPTION
Added new endpoints for service accounts and service account keys.
Also fixed an issue with optional parameters in object style.

ex:

```
smooch.apps.list({
    serviceAccountId: 'my_id'
})
```

would throw an error `limit must be a number`, because it was passing
`serviceAccountId` as the first arg to the `list` call, instead of
passing `undefined` for the `limit` and `offset` params, and then
passing `serviceAccountId` as 3rd param.