### PR TITLE
Merge constructor options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ var agent = new SocksProxyAgent(proxy);
 
 var smooch = new SmoochCore({
     keyId: 'some-key',
-    secret: 'some-secret'
-}, {
-  httpAgent: agent
+    secret: 'some-secret',
+    httpAgent: agent
 });
 ```
 

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -14,7 +14,6 @@ export class BaseApi {
     constructor(options) {
         this.serviceUrl = options.serviceUrl;
         this.authHeaders = options.authHeaders;
-        this.headers = options.headers;
         this.requireAppId = options.scope === 'account';
         this.httpAgent = options.httpAgent;
     }
@@ -51,7 +50,6 @@ export class BaseApi {
      */
     getHeaders() {
         return {
-            ...this.headers,
             ...this.authHeaders
         };
     }

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -12,7 +12,7 @@ import { http } from '../utils/http';
  */
 export class BaseApi {
     constructor(options) {
-        this.serviceUrl = options.serviceUrl;
+        this.serviceUrl = options.serviceUrl.replace(/\/$/, '');
         this.authHeaders = options.authHeaders;
         this.requireAppId = options.scope === 'account';
         this.httpAgent = options.httpAgent;

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -11,12 +11,12 @@ import { http } from '../utils/http';
  * @class BaseApi
  */
 export class BaseApi {
-    constructor(serviceUrl, authHeaders, headers, requireAppId, httpAgent) {
-        this.serviceUrl = serviceUrl;
-        this.authHeaders = authHeaders;
-        this.headers = headers;
-        this.requireAppId = !!requireAppId;
-        this.httpAgent = httpAgent;
+    constructor(options) {
+        this.serviceUrl = options.serviceUrl;
+        this.authHeaders = options.authHeaders;
+        this.headers = options.headers;
+        this.requireAppId = options.scope === 'account';
+        this.httpAgent = options.httpAgent;
     }
 
     /**

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -24,7 +24,7 @@ if (!global.FormData) {
 
 class Smooch {
     constructor(options = {}) {
-        const {serviceUrl = SERVICE_URL, headers = {}, httpAgent} = options;
+        const {serviceUrl = SERVICE_URL, httpAgent} = options;
         const auth = {
             keyId: options.keyId,
             secret: options.secret,
@@ -68,7 +68,6 @@ class Smooch {
             auth.scope = decoded.scope;
         }
 
-        this.headers = headers;
         this.httpAgent = httpAgent;
         this.serviceUrl = serviceUrl;
         this.VERSION = packageInfo.version;

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -23,8 +23,15 @@ if (!global.FormData) {
 }
 
 class Smooch {
-    constructor(auth = {}, options = {}) {
+    constructor(options = {}) {
         const {serviceUrl = SERVICE_URL, headers = {}, httpAgent} = options;
+        const auth = {
+            keyId: options.keyId,
+            secret: options.secret,
+            scope: options.scope,
+            jwt: options.jwt,
+            userId: options.userId
+        };
 
         if (auth.keyId || auth.secret) {
             if (!auth.scope) {
@@ -49,13 +56,8 @@ class Smooch {
                 jwtBody.userId = auth.userId;
             }
 
-            auth = {
-                jwt: jwt.generate(jwtBody, auth.secret, auth.keyId),
-                scope: auth.scope
-            };
-        }
-
-        if (auth.jwt) {
+            auth.jwt = jwt.generate(jwtBody, auth.secret, auth.keyId);
+        } else if (auth.jwt) {
             const decoded = decode(auth.jwt);
             if (!decoded) {
                 throw new Error('jwt is malformed.');
@@ -70,7 +72,7 @@ class Smooch {
         this.httpAgent = httpAgent;
         this.serviceUrl = serviceUrl;
         this.VERSION = packageInfo.version;
-        this.scope = auth.scope || 'appUser';
+        this.scope = auth.scope;
         this.authHeaders = getAuthenticationHeaders(auth);
 
         this.utils = {};

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -74,25 +74,22 @@ class Smooch {
         this.VERSION = packageInfo.version;
         this.scope = auth.scope;
         this.authHeaders = getAuthenticationHeaders(auth);
-
         this.utils = {};
 
-        const isAccountScope = this.scope === 'account';
-
-        this.menu = new MenuApi(this.serviceUrl, this.authHeaders, this.headers, isAccountScope, this.httpAgent);
-        this.webhooks = new WebhooksApi(this.serviceUrl, this.authHeaders, this.headers, isAccountScope, this.httpAgent);
-        this.attachments = new AttachmentsApi(this.serviceUrl, this.authHeaders, this.headers, isAccountScope, this.httpAgent);
-        this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers, isAccountScope, this.httpAgent);
-        this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders, isAccountScope, this.headers, this.httpAgent);
-        this.stripe = new StripeApi(this.serviceUrl, this.authHeaders, this.headers, isAccountScope, this.httpAgent);
+        this.menu = new MenuApi(this);
+        this.webhooks = new WebhooksApi(this);
+        this.attachments = new AttachmentsApi(this);
+        this.appUsers = new AppUsersApi(this);
+        this.conversations = new ConversationsApi(this);
+        this.stripe = new StripeApi(this);
 
         if (this.scope === 'account') {
-            this.integrations = new IntegrationsApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
-            this.apps = new AppsApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
-            this.appUsers = new AppUsersApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
-            this.conversations = new ConversationsApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
-            this.stripe = new StripeApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
-            this.serviceAccounts = new ServiceAccountsApi(this.serviceUrl, this.authHeaders, this.headers, true, this.httpAgent);
+            this.integrations = new IntegrationsApi(this);
+            this.apps = new AppsApi(this);
+            this.appUsers = new AppUsersApi(this);
+            this.conversations = new ConversationsApi(this);
+            this.stripe = new StripeApi(this);
+            this.serviceAccounts = new ServiceAccountsApi(this);
         } else {
             const disabled = new DisabledApi('This API requires account level scope');
             this.integrations = this.apps = disabled;

--- a/src/smooch.js
+++ b/src/smooch.js
@@ -16,7 +16,7 @@ import { decode } from 'jsonwebtoken';
 
 import packageInfo from '../package.json';
 
-const SERVICE_URL = 'https://api.smooch.io/v1';
+const SERVICE_URL = 'https://api.smooch.io';
 
 if (!global.FormData) {
     global.FormData = require('form-data');

--- a/src/utils/smoochMethod.js
+++ b/src/utils/smoochMethod.js
@@ -64,7 +64,7 @@ export default function smoochMethod({params, optional=[], path, method, func}) 
             }
         });
 
-        const url = this.serviceUrl + renderedPath;
+        const url = this.serviceUrl + '/v1' + renderedPath;
         if (method) {
             if (['POST', 'PUT'].includes(method)) {
                 // Payload object must always specified in the last arg

--- a/test/specs/api/appKeys.spec.js
+++ b/test/specs/api/appKeys.spec.js
@@ -40,7 +40,7 @@ describe('App Keys API', () => {
         it('should call http', () => {
             const keyName = 'key_12345';
             return api.create(appId, keyName).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/keys`;
+                const url = `${serviceUrl}/v1/apps/${appId}/keys`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: keyName
                 }, authHeaders);
@@ -51,7 +51,7 @@ describe('App Keys API', () => {
     describe('#list', () => {
         it('should call http', () => {
             return api.list(appId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/keys`;
+                const url = `${serviceUrl}/v1/apps/${appId}/keys`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -60,7 +60,7 @@ describe('App Keys API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(appId, keyId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/keys/${keyId}`;
+                const url = `${serviceUrl}/v1/apps/${appId}/keys/${keyId}`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -73,7 +73,7 @@ describe('App Keys API', () => {
     describe('#getJwt', () => {
         it('should call http', () => {
             return api.getJwt(appId, keyId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/keys/${keyId}/jwt`;
+                const url = `${serviceUrl}/v1/apps/${appId}/keys/${keyId}/jwt`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -86,7 +86,7 @@ describe('App Keys API', () => {
     describe('#delete', () => {
         it('should call http', () => {
             return api.delete(appId, keyId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/keys/${keyId}`;
+                const url = `${serviceUrl}/v1/apps/${appId}/keys/${keyId}`;
                 httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });

--- a/test/specs/api/appKeys.spec.js
+++ b/test/specs/api/appKeys.spec.js
@@ -6,9 +6,10 @@ import { testJwt } from '../../mocks/jwt';
 describe('App Keys API', () => {
     const serviceUrl = 'http://some-url.com';
     const missingParams = 'incorrect number of parameters';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
+    const scope = 'account';
     const appId = 'appid_12345';
     const keyId = 'key_12345';
     let httpSpy;
@@ -16,7 +17,11 @@ describe('App Keys API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new AppKeysApi(serviceUrl, httpHeaders, null, true);
+        api = new AppKeysApi({
+            serviceUrl,
+            authHeaders,
+            scope
+        });
     });
 
     afterEach(() => {
@@ -38,7 +43,7 @@ describe('App Keys API', () => {
                 const url = `${serviceUrl}/apps/${appId}/keys`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: keyName
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
     });
@@ -47,7 +52,7 @@ describe('App Keys API', () => {
         it('should call http', () => {
             return api.list(appId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/keys`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
     });
@@ -56,7 +61,7 @@ describe('App Keys API', () => {
         it('should call http', () => {
             return api.get(appId, keyId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/keys/${keyId}`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -69,7 +74,7 @@ describe('App Keys API', () => {
         it('should call http', () => {
             return api.getJwt(appId, keyId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/keys/${keyId}/jwt`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -82,7 +87,7 @@ describe('App Keys API', () => {
         it('should call http', () => {
             return api.delete(appId, keyId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/keys/${keyId}`;
-                httpSpy.should.have.been.calledWith('DELETE', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });
 

--- a/test/specs/api/appUsers.spec.js
+++ b/test/specs/api/appUsers.spec.js
@@ -7,7 +7,7 @@ import { testJwt } from '../../mocks/jwt';
 describe('AppUsers API', () => {
     const serviceUrl = 'http://some-url.com';
     const userId = 'user-id';
-    const httpHeaders = getAuthenticationHeaders({
+    let authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
 
@@ -16,7 +16,10 @@ describe('AppUsers API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new AppUsersApi(serviceUrl, httpHeaders);
+        api = new AppUsersApi({
+            serviceUrl,
+            authHeaders
+        });
     });
 
     afterEach(() => {
@@ -36,7 +39,7 @@ describe('AppUsers API', () => {
             return api.get(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}`;
 
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -49,7 +52,7 @@ describe('AppUsers API', () => {
 
             return api.update(userId, attributes).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}`;
-                httpSpy.should.have.been.calledWith('PUT', fullUrl, attributes, httpHeaders);
+                httpSpy.should.have.been.calledWith('PUT', fullUrl, attributes, authHeaders);
             });
         });
     });
@@ -61,22 +64,28 @@ describe('AppUsers API', () => {
             email: 'this is an email'
         };
 
-        const jwtHttpHeaders = getAuthenticationHeaders({
+        authHeaders = getAuthenticationHeaders({
             jwt: testJwt()
         });
 
         it('should call http', () => {
-            const jwtApi = new AppUsersApi(serviceUrl, jwtHttpHeaders);
+            const jwtApi = new AppUsersApi({
+                serviceUrl,
+                authHeaders
+            });
             return jwtApi.create(userId, props).then(() => {
                 const fullUrl = `${serviceUrl}/appusers`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, Object.assign({
                     userId: userId
-                }, props), jwtHttpHeaders);
+                }, props), authHeaders);
             });
         });
 
         it('should throw if signedUpAt is not a date object', (done) => {
-            const jwtApi = new AppUsersApi(serviceUrl, jwtHttpHeaders);
+            const jwtApi = new AppUsersApi({
+                serviceUrl,
+                authHeaders
+            });
             jwtApi.create(userId, {
                 signedUpAt: 'not a date'
             }).catch(() => {
@@ -90,7 +99,7 @@ describe('AppUsers API', () => {
             return api.getChannels(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/channels`;
 
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -100,7 +109,7 @@ describe('AppUsers API', () => {
             return api.getBusinessSystems(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/businesssystems`;
 
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -115,7 +124,7 @@ describe('AppUsers API', () => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/channels`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, {
                     ...data
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -130,7 +139,7 @@ describe('AppUsers API', () => {
         it('should call http', () => {
             return api.unlinkChannel(userId, 'twilio').then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/channels/twilio`;
-                httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -139,7 +148,7 @@ describe('AppUsers API', () => {
         it('should call http', () => {
             return api.pingChannel(userId, 'twilio').then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/integrations/twilio/ping`;
-                httpSpy.should.have.been.calledWith('POST', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -148,7 +157,7 @@ describe('AppUsers API', () => {
         it('should call http', () => {
             return api.getMessages(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
 
@@ -159,7 +168,7 @@ describe('AppUsers API', () => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, {
                     before: 'XYZ'
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -170,7 +179,7 @@ describe('AppUsers API', () => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, {
                     after: 'XYZ'
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -192,21 +201,24 @@ describe('AppUsers API', () => {
 
             return api.sendMessage(userId, message).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
-                httpSpy.should.have.been.calledWith('POST', fullUrl, message, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', fullUrl, message, authHeaders);
             });
         });
     });
 
     describe('#deleteMessages', () => {
-        const jwtHttpHeaders = getAuthenticationHeaders({
+        authHeaders = getAuthenticationHeaders({
             jwt: testJwt()
         });
 
         it('should call http', () => {
-            const jwtApi = new AppUsersApi(serviceUrl, jwtHttpHeaders);
+            const jwtApi = new AppUsersApi({
+                serviceUrl,
+                authHeaders
+            });
             return jwtApi.deleteMessages(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
-                httpSpy.should.have.been.calledWith('DELETE', fullUrl, {}, jwtHttpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', fullUrl, {}, authHeaders);
             });
         });
     });
@@ -220,7 +232,7 @@ describe('AppUsers API', () => {
 
             return api.typingActivity(userId, activity).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/activity`;
-                httpSpy.should.have.been.calledWith('POST', fullUrl, activity, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', fullUrl, activity, authHeaders);
             });
         });
     });
@@ -234,7 +246,7 @@ describe('AppUsers API', () => {
 
             return api.conversationActivity(userId, activity).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/activity`;
-                httpSpy.should.have.been.calledWith('POST', fullUrl, activity, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', fullUrl, activity, authHeaders);
             });
         });
     });
@@ -251,21 +263,24 @@ describe('AppUsers API', () => {
                 httpSpy.args[0][0].should.eq('POST');
                 httpSpy.args[0][1].should.eq(fullUrl);
                 httpSpy.args[0][2].should.be.instanceof(FormData);
-                httpSpy.args[0][3].should.eql(httpHeaders);
+                httpSpy.args[0][3].should.eql(authHeaders);
             });
         });
     });
 
     describe('#deleteProfile', () => {
-        const jwtHttpHeaders = getAuthenticationHeaders({
+        authHeaders = getAuthenticationHeaders({
             jwt: testJwt()
         });
 
         it('should call http', () => {
-            const jwtApi = new AppUsersApi(serviceUrl, jwtHttpHeaders);
+            const jwtApi = new AppUsersApi({
+                serviceUrl,
+                authHeaders
+            });
             return jwtApi.deleteProfile(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/profile`;
-                httpSpy.should.have.been.calledWith('DELETE', fullUrl, {}, jwtHttpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', fullUrl, {}, authHeaders);
             });
         });
     });
@@ -278,7 +293,7 @@ describe('AppUsers API', () => {
             return api.getLinkRequests(userId, integrationIds).then(() => {
                 httpSpy.should.have.been.calledWith('GET', fullUrl, {
                     integrationIds: integrationIds.join(',')
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -291,7 +306,7 @@ describe('AppUsers API', () => {
         it('should call http', () => {
             return api.getAuthCode(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/authcode`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });

--- a/test/specs/api/appUsers.spec.js
+++ b/test/specs/api/appUsers.spec.js
@@ -37,7 +37,7 @@ describe('AppUsers API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}`;
 
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
@@ -51,7 +51,7 @@ describe('AppUsers API', () => {
             };
 
             return api.update(userId, attributes).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}`;
                 httpSpy.should.have.been.calledWith('PUT', fullUrl, attributes, authHeaders);
             });
         });
@@ -74,7 +74,7 @@ describe('AppUsers API', () => {
                 authHeaders
             });
             return jwtApi.create(userId, props).then(() => {
-                const fullUrl = `${serviceUrl}/appusers`;
+                const fullUrl = `${serviceUrl}/v1/appusers`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, Object.assign({
                     userId: userId
                 }, props), authHeaders);
@@ -97,7 +97,7 @@ describe('AppUsers API', () => {
     describe('#getChannels', () => {
         it('should call http', () => {
             return api.getChannels(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/channels`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/channels`;
 
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
@@ -107,7 +107,7 @@ describe('AppUsers API', () => {
     describe('#getBusinessSystems', () => {
         it('should call http', () => {
             return api.getBusinessSystems(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/businesssystems`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/businesssystems`;
 
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
@@ -121,7 +121,7 @@ describe('AppUsers API', () => {
                 phoneNumber: '15145555555'
             };
             return api.linkChannel(userId, data).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/channels`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/channels`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, {
                     ...data
                 }, authHeaders);
@@ -138,7 +138,7 @@ describe('AppUsers API', () => {
     describe('#unlinkChannel', () => {
         it('should call http', () => {
             return api.unlinkChannel(userId, 'twilio').then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/channels/twilio`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/channels/twilio`;
                 httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, authHeaders);
             });
         });
@@ -147,7 +147,7 @@ describe('AppUsers API', () => {
     describe('#pingChannel', () => {
         it('should call http', () => {
             return api.pingChannel(userId, 'twilio').then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/integrations/twilio/ping`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/integrations/twilio/ping`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, undefined, authHeaders);
             });
         });
@@ -156,7 +156,7 @@ describe('AppUsers API', () => {
     describe('#getMessages', () => {
         it('should call http', () => {
             return api.getMessages(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
@@ -165,7 +165,7 @@ describe('AppUsers API', () => {
             return api.getMessages(userId, {
                 before: 'XYZ'
             }).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, {
                     before: 'XYZ'
                 }, authHeaders);
@@ -176,7 +176,7 @@ describe('AppUsers API', () => {
             return api.getMessages(userId, {
                 after: 'XYZ'
             }).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, {
                     after: 'XYZ'
                 }, authHeaders);
@@ -200,7 +200,7 @@ describe('AppUsers API', () => {
             };
 
             return api.sendMessage(userId, message).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, message, authHeaders);
             });
         });
@@ -217,7 +217,7 @@ describe('AppUsers API', () => {
                 authHeaders
             });
             return jwtApi.deleteMessages(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/messages`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/messages`;
                 httpSpy.should.have.been.calledWith('DELETE', fullUrl, {}, authHeaders);
             });
         });
@@ -231,7 +231,7 @@ describe('AppUsers API', () => {
             };
 
             return api.typingActivity(userId, activity).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/activity`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/conversation/activity`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, activity, authHeaders);
             });
         });
@@ -245,7 +245,7 @@ describe('AppUsers API', () => {
             };
 
             return api.conversationActivity(userId, activity).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/activity`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/conversation/activity`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, activity, authHeaders);
             });
         });
@@ -253,7 +253,7 @@ describe('AppUsers API', () => {
 
     describe('#uploadImage', () => {
         it('should call http', () => {
-            const fullUrl = `${serviceUrl}/appusers/${userId}/images`;
+            const fullUrl = `${serviceUrl}/v1/appusers/${userId}/images`;
             const source = createReadStream('some source object');
             const message = {
                 text: 'this is a message'
@@ -279,7 +279,7 @@ describe('AppUsers API', () => {
                 authHeaders
             });
             return jwtApi.deleteProfile(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/profile`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/profile`;
                 httpSpy.should.have.been.calledWith('DELETE', fullUrl, {}, authHeaders);
             });
         });
@@ -287,7 +287,7 @@ describe('AppUsers API', () => {
 
     describe('#getLinkRequests', () => {
         it('should call http', () => {
-            const fullUrl = `${serviceUrl}/appusers/${userId}/linkrequest`;
+            const fullUrl = `${serviceUrl}/v1/appusers/${userId}/linkrequest`;
 
             const integrationIds = ['5a04b5df045fedda49fa89f1', '5a04b5e0045fedda49fa89f2'];
             return api.getLinkRequests(userId, integrationIds).then(() => {
@@ -305,7 +305,7 @@ describe('AppUsers API', () => {
     describe('#getAuthCode', () => {
         it('should call http', () => {
             return api.getAuthCode(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/authcode`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/authcode`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });

--- a/test/specs/api/appUsersStripe.spec.js
+++ b/test/specs/api/appUsersStripe.spec.js
@@ -6,7 +6,7 @@ import { testJwt } from '../../mocks/jwt';
 describe('AppUsersStripe API', () => {
     const serviceUrl = 'http://some-url.com';
     const userId = 'user-id';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
     let httpSpy;
@@ -14,7 +14,7 @@ describe('AppUsersStripe API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new AppUsersStripeApi(serviceUrl, httpHeaders);
+        api = new AppUsersStripeApi({serviceUrl, authHeaders});
     });
 
     afterEach(() => {
@@ -27,7 +27,7 @@ describe('AppUsersStripe API', () => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/stripe/customer`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, {
                     token: 'token'
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -44,7 +44,7 @@ describe('AppUsersStripe API', () => {
                     httpSpy.should.have.been.calledWith('POST', fullUrl, {
                         actionId: 'actionId',
                         token: 'token'
-                    }, httpHeaders);
+                    }, authHeaders);
                 });
             });
 
@@ -61,7 +61,7 @@ describe('AppUsersStripe API', () => {
                     const fullUrl = `${serviceUrl}/appusers/${userId}/stripe/transaction`;
                     httpSpy.should.have.been.calledWith('POST', fullUrl, {
                         actionId: 'actionId'
-                    }, httpHeaders);
+                    }, authHeaders);
                 });
             });
 

--- a/test/specs/api/appUsersStripe.spec.js
+++ b/test/specs/api/appUsersStripe.spec.js
@@ -24,7 +24,7 @@ describe('AppUsersStripe API', () => {
     describe('#updateCustomer', () => {
         it('should call http', () => {
             return api.updateCustomer(userId, 'token').then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/stripe/customer`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/stripe/customer`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, {
                     token: 'token'
                 }, authHeaders);
@@ -40,7 +40,7 @@ describe('AppUsersStripe API', () => {
         describe('with token', () => {
             it('should call http', () => {
                 return api.createTransaction(userId, 'actionId', 'token').then(() => {
-                    const fullUrl = `${serviceUrl}/appusers/${userId}/stripe/transaction`;
+                    const fullUrl = `${serviceUrl}/v1/appusers/${userId}/stripe/transaction`;
                     httpSpy.should.have.been.calledWith('POST', fullUrl, {
                         actionId: 'actionId',
                         token: 'token'
@@ -58,7 +58,7 @@ describe('AppUsersStripe API', () => {
         describe('without token', () => {
             it('should call http', () => {
                 return api.createTransaction(userId, 'actionId').then(() => {
-                    const fullUrl = `${serviceUrl}/appusers/${userId}/stripe/transaction`;
+                    const fullUrl = `${serviceUrl}/v1/appusers/${userId}/stripe/transaction`;
                     httpSpy.should.have.been.calledWith('POST', fullUrl, {
                         actionId: 'actionId'
                     }, authHeaders);

--- a/test/specs/api/appUsersViber.spec.js
+++ b/test/specs/api/appUsersViber.spec.js
@@ -24,7 +24,7 @@ describe('AppUsersViber API', () => {
     describe('#getQRCode', () => {
         it('should call http', () => {
             return api.getQRCode(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/integrations/viber/qrcode`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/integrations/viber/qrcode`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });

--- a/test/specs/api/appUsersViber.spec.js
+++ b/test/specs/api/appUsersViber.spec.js
@@ -6,7 +6,7 @@ import { testJwt } from '../../mocks/jwt';
 describe('AppUsersViber API', () => {
     const serviceUrl = 'http://some-url.com';
     const userId = 'user-id';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
     let httpSpy;
@@ -14,7 +14,7 @@ describe('AppUsersViber API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new AppUsersViberApi(serviceUrl, httpHeaders);
+        api = new AppUsersViberApi({serviceUrl, authHeaders});
     });
 
     afterEach(() => {
@@ -25,7 +25,7 @@ describe('AppUsersViber API', () => {
         it('should call http', () => {
             return api.getQRCode(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/integrations/viber/qrcode`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });

--- a/test/specs/api/appUsersWeChat.spec.js
+++ b/test/specs/api/appUsersWeChat.spec.js
@@ -6,7 +6,7 @@ import { testJwt } from '../../mocks/jwt';
 describe('AppUsersWeChat API', () => {
     const serviceUrl = 'http://some-url.com';
     const userId = 'user-id';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
     let httpSpy;
@@ -14,7 +14,7 @@ describe('AppUsersWeChat API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new AppUsersWeChatApi(serviceUrl, httpHeaders);
+        api = new AppUsersWeChatApi({serviceUrl, authHeaders});
     });
 
     afterEach(() => {
@@ -25,7 +25,7 @@ describe('AppUsersWeChat API', () => {
         it('should call http', () => {
             return api.getQRCode(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/integrations/wechat/qrcode`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });

--- a/test/specs/api/appUsersWeChat.spec.js
+++ b/test/specs/api/appUsersWeChat.spec.js
@@ -24,7 +24,7 @@ describe('AppUsersWeChat API', () => {
     describe('#getQRCode', () => {
         it('should call http', () => {
             return api.getQRCode(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/integrations/wechat/qrcode`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/integrations/wechat/qrcode`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });

--- a/test/specs/api/apps.spec.js
+++ b/test/specs/api/apps.spec.js
@@ -37,7 +37,7 @@ describe('Apps API', () => {
 
         it('should call http', () => {
             return api.create(appName).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/v1/apps`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: appName
                 }, authHeaders);
@@ -49,7 +49,7 @@ describe('Apps API', () => {
                 name: appName,
                 settings: {}
             }).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/v1/apps`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: appName,
                     settings: {}
@@ -63,14 +63,14 @@ describe('Apps API', () => {
         const offset = 99;
         it('should call http with no limit or offset', () => {
             return api.list().then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/v1/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
         it('should use limit', () => {
             return api.list(limit).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/v1/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit
                 }, authHeaders);
@@ -79,7 +79,7 @@ describe('Apps API', () => {
 
         it('should use offset', () => {
             return api.list(undefined, offset).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/v1/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     offset
                 }, authHeaders);
@@ -88,7 +88,7 @@ describe('Apps API', () => {
 
         it('should use both', () => {
             return api.list(limit, offset).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/v1/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit,
                     offset
@@ -99,7 +99,7 @@ describe('Apps API', () => {
         it('should use serviceAccountId', () => {
             const serviceAccountId = hat();
             return api.list(undefined, undefined, serviceAccountId).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/v1/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     serviceAccountId
                 }, authHeaders);
@@ -109,7 +109,7 @@ describe('Apps API', () => {
         it('should use all three', () => {
             const serviceAccountId = hat();
             return api.list(limit, offset, serviceAccountId).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/v1/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit,
                     offset,
@@ -124,7 +124,7 @@ describe('Apps API', () => {
             return api.list({
                 serviceAccountId
             }).then(() => {
-                const url = `${serviceUrl}/apps`;
+                const url = `${serviceUrl}/v1/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     serviceAccountId
                 }, authHeaders);
@@ -147,7 +147,7 @@ describe('Apps API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(appId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}`;
+                const url = `${serviceUrl}/v1/apps/${appId}`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -165,7 +165,7 @@ describe('Apps API', () => {
                 name: appName,
                 settings: {}
             }).then(() => {
-                const url = `${serviceUrl}/apps/${appId}`;
+                const url = `${serviceUrl}/v1/apps/${appId}`;
                 httpSpy.should.have.been.calledWith('PUT', url, {
                     name: appName,
                     settings: {}
@@ -182,7 +182,7 @@ describe('Apps API', () => {
         it('should call http', () => {
             const appId = 'app_123456';
             return api.delete(appId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}`;
+                const url = `${serviceUrl}/v1/apps/${appId}`;
                 httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });

--- a/test/specs/api/apps.spec.js
+++ b/test/specs/api/apps.spec.js
@@ -8,9 +8,10 @@ import { testJwt } from '../../mocks/jwt';
 describe('Apps API', () => {
     const serviceUrl = 'http://some-url.com';
     const missingParams = 'incorrect number of parameters';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
+    const scope = 'app';
     const appId = 'appid_12345';
     const appName = 'My Awesome Unit Test App';
     let httpSpy;
@@ -18,7 +19,7 @@ describe('Apps API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new AppsApi(serviceUrl, httpHeaders, null, false);
+        api = new AppsApi({serviceUrl, authHeaders, scope});
     });
 
     afterEach(() => {
@@ -39,7 +40,7 @@ describe('Apps API', () => {
                 const url = `${serviceUrl}/apps`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: appName
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -52,7 +53,7 @@ describe('Apps API', () => {
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: appName,
                     settings: {}
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
     });
@@ -63,7 +64,7 @@ describe('Apps API', () => {
         it('should call http with no limit or offset', () => {
             return api.list().then(() => {
                 const url = `${serviceUrl}/apps`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -72,7 +73,7 @@ describe('Apps API', () => {
                 const url = `${serviceUrl}/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -81,7 +82,7 @@ describe('Apps API', () => {
                 const url = `${serviceUrl}/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     offset
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -91,7 +92,7 @@ describe('Apps API', () => {
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit,
                     offset
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -101,7 +102,7 @@ describe('Apps API', () => {
                 const url = `${serviceUrl}/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     serviceAccountId
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -113,7 +114,7 @@ describe('Apps API', () => {
                     limit,
                     offset,
                     serviceAccountId
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -126,7 +127,7 @@ describe('Apps API', () => {
                 const url = `${serviceUrl}/apps`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     serviceAccountId
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -147,7 +148,7 @@ describe('Apps API', () => {
         it('should call http', () => {
             return api.get(appId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -168,7 +169,7 @@ describe('Apps API', () => {
                 httpSpy.should.have.been.calledWith('PUT', url, {
                     name: appName,
                     settings: {}
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -182,7 +183,7 @@ describe('Apps API', () => {
             const appId = 'app_123456';
             return api.delete(appId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}`;
-                httpSpy.should.have.been.calledWith('DELETE', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });
 

--- a/test/specs/api/attachments.spec.js
+++ b/test/specs/api/attachments.spec.js
@@ -10,13 +10,14 @@ describe('Attachments API', () => {
     let httpSpy;
     let api;
 
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
+    const scope = 'app';
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new AttachmentsApi(serviceUrl, httpHeaders, null, false);
+        api = new AttachmentsApi({serviceUrl, authHeaders, scope});
     });
 
     afterEach(() => {
@@ -32,7 +33,7 @@ describe('Attachments API', () => {
                 httpSpy.args[0][0].should.eq('POST');
                 httpSpy.args[0][1].should.eq(fullUrl);
                 httpSpy.args[0][2].should.be.instanceof(FormData);
-                httpSpy.args[0][3].should.eql(httpHeaders);
+                httpSpy.args[0][3].should.eql(authHeaders);
             });
         });
     });

--- a/test/specs/api/attachments.spec.js
+++ b/test/specs/api/attachments.spec.js
@@ -26,7 +26,7 @@ describe('Attachments API', () => {
 
     describe('#create', () => {
         it('should call http', () => {
-            const fullUrl = `${serviceUrl}/attachments?access=public`;
+            const fullUrl = `${serviceUrl}/v1/attachments?access=public`;
             const source = createReadStream('some source object');
 
             return api.create('public', source).then(() => {

--- a/test/specs/api/base.spec.js
+++ b/test/specs/api/base.spec.js
@@ -2,26 +2,33 @@ import { BaseApi } from '../../../src/api/base';
 import { testJwt } from '../../mocks/jwt';
 
 const serviceUrl = 'http://some-url.com';
-const headers = {
+const authHeaders = {
     jwt: testJwt()
 };
 
 describe('Base API', () => {
     describe('#constructor', () => {
         it('should set service URL and auth headers', () => {
-            const api = new BaseApi(serviceUrl, headers);
+            const api = new BaseApi({
+                serviceUrl,
+                authHeaders
+            });
 
             api.serviceUrl.should.equal(serviceUrl);
-            api.authHeaders.should.equal(headers);
+            api.authHeaders.should.equal(authHeaders);
         });
     });
 
     describe('#getHeaders', function() {
         it('should include auth headers and custom headers', () => {
-            const api = new BaseApi(serviceUrl, {
-                Authorization: 'Bearer stuff'
-            }, {
-                customHeader: '1234'
+            const api = new BaseApi({
+                serviceUrl,
+                authHeaders: {
+                    Authorization: 'Bearer stuff'
+                },
+                headers: {
+                    customHeader: '1234'
+                }
             });
 
             api.getHeaders().should.eql({
@@ -33,8 +40,11 @@ describe('Base API', () => {
 
     describe('#validateAuthHeaders', () => {
         it('should not return an error if Authorization header is present', () => {
-            const api = new BaseApi(serviceUrl, {
-                Authorization: 'Bearer stuff'
+            const api = new BaseApi({
+                serviceUrl,
+                authHeaders: {
+                    Authorization: 'Bearer stuff'
+                }
             });
 
             return api.validateAuthHeaders();

--- a/test/specs/api/base.spec.js
+++ b/test/specs/api/base.spec.js
@@ -17,6 +17,16 @@ describe('Base API', () => {
             api.serviceUrl.should.equal(serviceUrl);
             api.authHeaders.should.equal(authHeaders);
         });
+
+        it('should strip trailing slash in serviceUrl', () => {
+            const api = new BaseApi({
+                serviceUrl: serviceUrl + '/',
+                authHeaders
+            });
+
+            api.serviceUrl.should.equal(serviceUrl);
+            api.authHeaders.should.equal(authHeaders);
+        });
     });
 
     describe('#getHeaders', function() {

--- a/test/specs/api/base.spec.js
+++ b/test/specs/api/base.spec.js
@@ -20,20 +20,16 @@ describe('Base API', () => {
     });
 
     describe('#getHeaders', function() {
-        it('should include auth headers and custom headers', () => {
+        it('should include auth headers', () => {
             const api = new BaseApi({
                 serviceUrl,
                 authHeaders: {
                     Authorization: 'Bearer stuff'
-                },
-                headers: {
-                    customHeader: '1234'
                 }
             });
 
             api.getHeaders().should.eql({
-                Authorization: 'Bearer stuff',
-                customHeader: '1234'
+                Authorization: 'Bearer stuff'
             });
         });
     });
@@ -51,8 +47,9 @@ describe('Base API', () => {
         });
 
         it('should return an error if Authorization header is not present', (done) => {
-            const api = new BaseApi(serviceUrl, {
-                'something': 'whatever'
+            const api = new BaseApi({
+                serviceUrl,
+                authHeaders: {}
             });
 
             api.validateAuthHeaders().catch(() => {

--- a/test/specs/api/conversations.spec.js
+++ b/test/specs/api/conversations.spec.js
@@ -8,7 +8,7 @@ import { testJwt } from '../../mocks/jwt';
 describe('Conversations API', () => {
     const serviceUrl = 'http://some-url.com';
     const userId = 'user-id';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
     let httpSpy;
@@ -16,7 +16,7 @@ describe('Conversations API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new ConversationsApi(serviceUrl, httpHeaders);
+        api = new ConversationsApi({serviceUrl, authHeaders});
     });
 
     afterEach(() => {
@@ -27,7 +27,7 @@ describe('Conversations API', () => {
         it('should call http', () => {
             return api.get(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/conversation`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -40,7 +40,7 @@ describe('Conversations API', () => {
 
             return api.postPostback(userId, body.actionId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/postback`;
-                httpSpy.should.have.been.calledWith('POST', fullUrl, body, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', fullUrl, body, authHeaders);
             });
         });
     });
@@ -74,7 +74,7 @@ describe('Conversations API', () => {
         it('should call http', () => {
             return api.resetUnreadCount(userId).then(() => {
                 const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/read`;
-                httpSpy.should.have.been.calledWith('POST', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', fullUrl, undefined, authHeaders);
             });
         });
     });

--- a/test/specs/api/conversations.spec.js
+++ b/test/specs/api/conversations.spec.js
@@ -26,7 +26,7 @@ describe('Conversations API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/conversation`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/conversation`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
@@ -39,7 +39,7 @@ describe('Conversations API', () => {
             };
 
             return api.postPostback(userId, body.actionId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/postback`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/conversation/postback`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, body, authHeaders);
             });
         });
@@ -73,7 +73,7 @@ describe('Conversations API', () => {
     describe('#resetUnreadCount', () => {
         it('should call http', () => {
             return api.resetUnreadCount(userId).then(() => {
-                const fullUrl = `${serviceUrl}/appusers/${userId}/conversation/read`;
+                const fullUrl = `${serviceUrl}/v1/appusers/${userId}/conversation/read`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, undefined, authHeaders);
             });
         });

--- a/test/specs/api/integrationMenu.spec.js
+++ b/test/specs/api/integrationMenu.spec.js
@@ -7,9 +7,10 @@ describe('Integration Menu API', () => {
     const serviceUrl = 'http://some-url.com';
     const noPropsMessage = 'Must provide props.';
     const noItemsMessage = 'Must provide an array of items.';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
+    const scope = 'account';
     const appId = 'appid_12345';
     const integrationId = 'integrationid_12345';
     let httpSpy;
@@ -17,7 +18,7 @@ describe('Integration Menu API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new IntegrationMenuApi(serviceUrl, httpHeaders, null, true);
+        api = new IntegrationMenuApi({serviceUrl, authHeaders, scope});
     });
 
     afterEach(() => {
@@ -28,7 +29,7 @@ describe('Integration Menu API', () => {
         it('should call http', () => {
             return api.get(appId, integrationId).then(() => {
                 const fullUrl = `${serviceUrl}/apps/${appId}/integrations/${integrationId}/menu`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -42,7 +43,7 @@ describe('Integration Menu API', () => {
             api.create(appId, integrationId, props)
             .then(() => {
                 const fullUrl = `${serviceUrl}/apps/${appId}/integrations/${integrationId}/menu`;
-                httpSpy.should.have.been.calledWith('POST', fullUrl, props, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', fullUrl, props, authHeaders);
                 done();
             });
         });
@@ -74,7 +75,7 @@ describe('Integration Menu API', () => {
         it('should call http', () => {
             return api.update(appId, integrationId, props).then(() => {
                 const fullUrl = `${serviceUrl}/apps/${appId}/integrations/${integrationId}/menu`;
-                httpSpy.should.have.been.calledWith('PUT', fullUrl, props, httpHeaders);
+                httpSpy.should.have.been.calledWith('PUT', fullUrl, props, authHeaders);
             });
         });
 
@@ -101,7 +102,7 @@ describe('Integration Menu API', () => {
         it('should call http', () => {
             return api.delete(appId, integrationId).then(() => {
                 const fullUrl = `${serviceUrl}/apps/${appId}/integrations/${integrationId}/menu`;
-                httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, authHeaders);
             });
         });
     });

--- a/test/specs/api/integrationMenu.spec.js
+++ b/test/specs/api/integrationMenu.spec.js
@@ -28,7 +28,7 @@ describe('Integration Menu API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(appId, integrationId).then(() => {
-                const fullUrl = `${serviceUrl}/apps/${appId}/integrations/${integrationId}/menu`;
+                const fullUrl = `${serviceUrl}/v1/apps/${appId}/integrations/${integrationId}/menu`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
@@ -42,7 +42,7 @@ describe('Integration Menu API', () => {
         it('should call http', (done) => {
             api.create(appId, integrationId, props)
             .then(() => {
-                const fullUrl = `${serviceUrl}/apps/${appId}/integrations/${integrationId}/menu`;
+                const fullUrl = `${serviceUrl}/v1/apps/${appId}/integrations/${integrationId}/menu`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, props, authHeaders);
                 done();
             });
@@ -74,7 +74,7 @@ describe('Integration Menu API', () => {
 
         it('should call http', () => {
             return api.update(appId, integrationId, props).then(() => {
-                const fullUrl = `${serviceUrl}/apps/${appId}/integrations/${integrationId}/menu`;
+                const fullUrl = `${serviceUrl}/v1/apps/${appId}/integrations/${integrationId}/menu`;
                 httpSpy.should.have.been.calledWith('PUT', fullUrl, props, authHeaders);
             });
         });
@@ -101,7 +101,7 @@ describe('Integration Menu API', () => {
     describe('#delete', () => {
         it('should call http', () => {
             return api.delete(appId, integrationId).then(() => {
-                const fullUrl = `${serviceUrl}/apps/${appId}/integrations/${integrationId}/menu`;
+                const fullUrl = `${serviceUrl}/v1/apps/${appId}/integrations/${integrationId}/menu`;
                 httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, authHeaders);
             });
         });

--- a/test/specs/api/integrations.spec.js
+++ b/test/specs/api/integrations.spec.js
@@ -49,7 +49,7 @@ describe('Integrations API', () => {
                     buttonIconUrl: 'https://pbs.twimg.com/media/CtooA-VWIAAViqN.jpg'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -71,7 +71,7 @@ describe('Integrations API', () => {
                     appSecret: 'baz'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -94,7 +94,7 @@ describe('Integrations API', () => {
                     accessTokenSecret: 'schwifty'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -116,7 +116,7 @@ describe('Integrations API', () => {
                     incomingAddress: 'baz'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -138,7 +138,7 @@ describe('Integrations API', () => {
                     phoneNumberSid: 'baz'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -158,7 +158,7 @@ describe('Integrations API', () => {
                     token: 'foo'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -179,7 +179,7 @@ describe('Integrations API', () => {
                     channelSecret: 'bar'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -199,7 +199,7 @@ describe('Integrations API', () => {
                     token: 'foo'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -220,7 +220,7 @@ describe('Integrations API', () => {
                     appSecret: 'bar'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -233,7 +233,7 @@ describe('Integrations API', () => {
                     encodingAesKey: 'baz'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -255,7 +255,7 @@ describe('Integrations API', () => {
                     senderId: 'woo'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -276,7 +276,7 @@ describe('Integrations API', () => {
                     certificate: 'yay'
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -289,7 +289,7 @@ describe('Integrations API', () => {
                     autoUpdateBadge: true
                 };
                 return api.create(appId, props).then(() => {
-                    const url = `${serviceUrl}/apps/${appId}/integrations`;
+                    const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                     httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
@@ -322,7 +322,7 @@ describe('Integrations API', () => {
     describe('#list', () => {
         it('should call http', () => {
             return api.list(appId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/integrations`;
+                const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -330,7 +330,7 @@ describe('Integrations API', () => {
         it('should accept types string', () => {
             const types = 'type1,type2';
             return api.list(appId, types).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/integrations`;
+                const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     types
                 }, authHeaders);
@@ -340,7 +340,7 @@ describe('Integrations API', () => {
         it('should accept types array', () => {
             const types = ['type1', 'type2'];
             return api.list(appId, types).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/integrations`;
+                const url = `${serviceUrl}/v1/apps/${appId}/integrations`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     types: 'type1,type2'
                 }, authHeaders);
@@ -352,7 +352,7 @@ describe('Integrations API', () => {
         it('should call http', () => {
             const integrationId = 'integration_123456';
             return api.get(appId, integrationId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/integrations/${integrationId}`;
+                const url = `${serviceUrl}/v1/apps/${appId}/integrations/${integrationId}`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -366,7 +366,7 @@ describe('Integrations API', () => {
         it('should call http', () => {
             const integrationId = 'integration_123456';
             return api.update(appId, integrationId, {}).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/integrations/${integrationId}`;
+                const url = `${serviceUrl}/v1/apps/${appId}/integrations/${integrationId}`;
                 httpSpy.should.have.been.calledWith('PUT', url, {}, authHeaders);
             });
         });
@@ -380,7 +380,7 @@ describe('Integrations API', () => {
         it('should call http', () => {
             const integrationId = 'integration_123456';
             return api.delete(appId, integrationId).then(() => {
-                const url = `${serviceUrl}/apps/${appId}/integrations/${integrationId}`;
+                const url = `${serviceUrl}/v1/apps/${appId}/integrations/${integrationId}`;
                 httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });

--- a/test/specs/api/integrations.spec.js
+++ b/test/specs/api/integrations.spec.js
@@ -6,16 +6,17 @@ import { testJwt } from '../../mocks/jwt';
 describe('Integrations API', () => {
     const serviceUrl = 'http://some-url.com';
     const missingParams = 'incorrect number of parameters';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
+    const scope = 'account';
     const appId = 'appid_12345';
     let httpSpy;
     let api;
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new IntegrationsApi(serviceUrl, httpHeaders, null, true);
+        api = new IntegrationsApi({serviceUrl, authHeaders, scope});
     });
 
     afterEach(() => {
@@ -49,7 +50,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -71,7 +72,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -94,7 +95,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -116,7 +117,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -138,7 +139,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -158,7 +159,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -179,7 +180,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -199,7 +200,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -220,7 +221,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
 
@@ -233,7 +234,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -255,7 +256,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
         });
@@ -276,7 +277,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
 
@@ -289,7 +290,7 @@ describe('Integrations API', () => {
                 };
                 return api.create(appId, props).then(() => {
                     const url = `${serviceUrl}/apps/${appId}/integrations`;
-                    httpSpy.should.have.been.calledWith('POST', url, props, httpHeaders);
+                    httpSpy.should.have.been.calledWith('POST', url, props, authHeaders);
                 });
             });
 
@@ -322,7 +323,7 @@ describe('Integrations API', () => {
         it('should call http', () => {
             return api.list(appId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/integrations`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -332,7 +333,7 @@ describe('Integrations API', () => {
                 const url = `${serviceUrl}/apps/${appId}/integrations`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     types
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -342,7 +343,7 @@ describe('Integrations API', () => {
                 const url = `${serviceUrl}/apps/${appId}/integrations`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     types: 'type1,type2'
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
     });
@@ -352,7 +353,7 @@ describe('Integrations API', () => {
             const integrationId = 'integration_123456';
             return api.get(appId, integrationId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/integrations/${integrationId}`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -366,7 +367,7 @@ describe('Integrations API', () => {
             const integrationId = 'integration_123456';
             return api.update(appId, integrationId, {}).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/integrations/${integrationId}`;
-                httpSpy.should.have.been.calledWith('PUT', url, {}, httpHeaders);
+                httpSpy.should.have.been.calledWith('PUT', url, {}, authHeaders);
             });
         });
 
@@ -380,7 +381,7 @@ describe('Integrations API', () => {
             const integrationId = 'integration_123456';
             return api.delete(appId, integrationId).then(() => {
                 const url = `${serviceUrl}/apps/${appId}/integrations/${integrationId}`;
-                httpSpy.should.have.been.calledWith('DELETE', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });
 

--- a/test/specs/api/menu.spec.js
+++ b/test/specs/api/menu.spec.js
@@ -25,7 +25,7 @@ describe('Menu API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get().then(() => {
-                const fullUrl = `${serviceUrl}/menu`;
+                const fullUrl = `${serviceUrl}/v1/menu`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
@@ -39,7 +39,7 @@ describe('Menu API', () => {
 
         it('should call http', () => {
             return api.configure(props).then(() => {
-                const fullUrl = `${serviceUrl}/menu`;
+                const fullUrl = `${serviceUrl}/v1/menu`;
                 httpSpy.should.have.been.calledWith('PUT', fullUrl, props, authHeaders);
             });
         });
@@ -64,7 +64,7 @@ describe('Menu API', () => {
     describe('#remove', () => {
         it('should call http', () => {
             return api.remove().then(() => {
-                const fullUrl = `${serviceUrl}/menu`;
+                const fullUrl = `${serviceUrl}/v1/menu`;
                 httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, authHeaders);
             });
         });

--- a/test/specs/api/menu.spec.js
+++ b/test/specs/api/menu.spec.js
@@ -7,7 +7,7 @@ describe('Menu API', () => {
     const serviceUrl = 'http://some-url.com';
     const noPropsMessage = 'Must provide props.';
     const noItemsMessage = 'Must provide an array of items.';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
     let httpSpy;
@@ -15,7 +15,7 @@ describe('Menu API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new MenuApi(serviceUrl, httpHeaders);
+        api = new MenuApi({serviceUrl, authHeaders});
     });
 
     afterEach(() => {
@@ -26,7 +26,7 @@ describe('Menu API', () => {
         it('should call http', () => {
             return api.get().then(() => {
                 const fullUrl = `${serviceUrl}/menu`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -40,7 +40,7 @@ describe('Menu API', () => {
         it('should call http', () => {
             return api.configure(props).then(() => {
                 const fullUrl = `${serviceUrl}/menu`;
-                httpSpy.should.have.been.calledWith('PUT', fullUrl, props, httpHeaders);
+                httpSpy.should.have.been.calledWith('PUT', fullUrl, props, authHeaders);
             });
         });
 
@@ -65,7 +65,7 @@ describe('Menu API', () => {
         it('should call http', () => {
             return api.remove().then(() => {
                 const fullUrl = `${serviceUrl}/menu`;
-                httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, authHeaders);
             });
         });
     });

--- a/test/specs/api/serviceAccountKeys.spec.js
+++ b/test/specs/api/serviceAccountKeys.spec.js
@@ -5,12 +5,13 @@ import { getAuthenticationHeaders } from '../../../src/utils/auth';
 import { ServiceAccountKeysApi } from '../../../src/api/serviceAccountKeys';
 import { testJwt } from '../../mocks/jwt';
 
-describe('App Keys API', () => {
+describe('Service Account Keys API', () => {
     const serviceUrl = 'http://some-url.com';
     const missingParams = 'incorrect number of parameters';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
+    const scope = 'account';
     const serviceAccountId = hat();
     const keyId = hat();
     let httpSpy;
@@ -18,7 +19,7 @@ describe('App Keys API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new ServiceAccountKeysApi(serviceUrl, httpHeaders, null, true);
+        api = new ServiceAccountKeysApi({serviceUrl, authHeaders, scope});
     });
 
     afterEach(() => {
@@ -40,7 +41,7 @@ describe('App Keys API', () => {
                 const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: keyName
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
     });
@@ -49,7 +50,7 @@ describe('App Keys API', () => {
         it('should call http', () => {
             return api.list(serviceAccountId).then(() => {
                 const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
     });
@@ -58,7 +59,7 @@ describe('App Keys API', () => {
         it('should call http', () => {
             return api.get(serviceAccountId, keyId).then(() => {
                 const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys/${keyId}`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -71,7 +72,7 @@ describe('App Keys API', () => {
         it('should call http', () => {
             return api.getJwt(serviceAccountId, keyId).then(() => {
                 const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys/${keyId}/jwt`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -84,7 +85,7 @@ describe('App Keys API', () => {
         it('should call http', () => {
             return api.delete(serviceAccountId, keyId).then(() => {
                 const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys/${keyId}`;
-                httpSpy.should.have.been.calledWith('DELETE', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });
 

--- a/test/specs/api/serviceAccountKeys.spec.js
+++ b/test/specs/api/serviceAccountKeys.spec.js
@@ -38,7 +38,7 @@ describe('Service Account Keys API', () => {
         it('should call http', () => {
             const keyName = hat();
             return api.create(serviceAccountId, keyName).then(() => {
-                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys`;
+                const url = `${serviceUrl}/v1/serviceaccounts/${serviceAccountId}/keys`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: keyName
                 }, authHeaders);
@@ -49,7 +49,7 @@ describe('Service Account Keys API', () => {
     describe('#list', () => {
         it('should call http', () => {
             return api.list(serviceAccountId).then(() => {
-                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys`;
+                const url = `${serviceUrl}/v1/serviceaccounts/${serviceAccountId}/keys`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -58,7 +58,7 @@ describe('Service Account Keys API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(serviceAccountId, keyId).then(() => {
-                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys/${keyId}`;
+                const url = `${serviceUrl}/v1/serviceaccounts/${serviceAccountId}/keys/${keyId}`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -71,7 +71,7 @@ describe('Service Account Keys API', () => {
     describe('#getJwt', () => {
         it('should call http', () => {
             return api.getJwt(serviceAccountId, keyId).then(() => {
-                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys/${keyId}/jwt`;
+                const url = `${serviceUrl}/v1/serviceaccounts/${serviceAccountId}/keys/${keyId}/jwt`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -84,7 +84,7 @@ describe('Service Account Keys API', () => {
     describe('#delete', () => {
         it('should call http', () => {
             return api.delete(serviceAccountId, keyId).then(() => {
-                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}/keys/${keyId}`;
+                const url = `${serviceUrl}/v1/serviceaccounts/${serviceAccountId}/keys/${keyId}`;
                 httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });

--- a/test/specs/api/serviceAccounts.spec.js
+++ b/test/specs/api/serviceAccounts.spec.js
@@ -8,9 +8,10 @@ import { testJwt } from '../../mocks/jwt';
 describe('Service Accounts API', () => {
     const serviceUrl = 'http://some-url.com';
     const missingParams = 'incorrect number of parameters';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
+    const scope = 'app';
     const serviceAccountId = hat();
     const serviceAccountName = hat();
     let httpSpy;
@@ -18,7 +19,7 @@ describe('Service Accounts API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new ServiceAccountsApi(serviceUrl, httpHeaders, null, false);
+        api = new ServiceAccountsApi({serviceUrl, authHeaders, scope});
     });
 
     afterEach(() => {
@@ -39,7 +40,7 @@ describe('Service Accounts API', () => {
                 const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: serviceAccountName
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -50,7 +51,7 @@ describe('Service Accounts API', () => {
                 const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: serviceAccountName
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
     });
@@ -61,7 +62,7 @@ describe('Service Accounts API', () => {
         it('should call http with no limit or offset', () => {
             return api.list().then(() => {
                 const url = `${serviceUrl}/serviceaccounts`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -70,7 +71,7 @@ describe('Service Accounts API', () => {
                 const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -79,7 +80,7 @@ describe('Service Accounts API', () => {
                 const url = `${serviceUrl}/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     offset
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -89,7 +90,7 @@ describe('Service Accounts API', () => {
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit,
                     offset
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -104,7 +105,7 @@ describe('Service Accounts API', () => {
         it('should call http', () => {
             return api.get(serviceAccountId).then(() => {
                 const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}`;
-                httpSpy.should.have.been.calledWith('GET', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
@@ -121,7 +122,7 @@ describe('Service Accounts API', () => {
                 const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}`;
                 httpSpy.should.have.been.calledWith('PUT', url, {
                     name: serviceAccountName
-                }, httpHeaders);
+                }, authHeaders);
             });
         });
 
@@ -134,7 +135,7 @@ describe('Service Accounts API', () => {
         it('should call http', () => {
             return api.delete(serviceAccountId).then(() => {
                 const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}`;
-                httpSpy.should.have.been.calledWith('DELETE', url, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });
 

--- a/test/specs/api/serviceAccounts.spec.js
+++ b/test/specs/api/serviceAccounts.spec.js
@@ -37,7 +37,7 @@ describe('Service Accounts API', () => {
 
         it('should call http', () => {
             return api.create(serviceAccountName).then(() => {
-                const url = `${serviceUrl}/serviceaccounts`;
+                const url = `${serviceUrl}/v1/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: serviceAccountName
                 }, authHeaders);
@@ -48,7 +48,7 @@ describe('Service Accounts API', () => {
             return api.create({
                 name: serviceAccountName
             }).then(() => {
-                const url = `${serviceUrl}/serviceaccounts`;
+                const url = `${serviceUrl}/v1/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('POST', url, {
                     name: serviceAccountName
                 }, authHeaders);
@@ -61,14 +61,14 @@ describe('Service Accounts API', () => {
         const offset = 99;
         it('should call http with no limit or offset', () => {
             return api.list().then(() => {
-                const url = `${serviceUrl}/serviceaccounts`;
+                const url = `${serviceUrl}/v1/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
 
         it('should use limit', () => {
             return api.list(limit).then(() => {
-                const url = `${serviceUrl}/serviceaccounts`;
+                const url = `${serviceUrl}/v1/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit
                 }, authHeaders);
@@ -77,7 +77,7 @@ describe('Service Accounts API', () => {
 
         it('should use offset', () => {
             return api.list(undefined, offset).then(() => {
-                const url = `${serviceUrl}/serviceaccounts`;
+                const url = `${serviceUrl}/v1/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     offset
                 }, authHeaders);
@@ -86,7 +86,7 @@ describe('Service Accounts API', () => {
 
         it('should use both', () => {
             return api.list(limit, offset).then(() => {
-                const url = `${serviceUrl}/serviceaccounts`;
+                const url = `${serviceUrl}/v1/serviceaccounts`;
                 httpSpy.should.have.been.calledWith('GET', url, {
                     limit,
                     offset
@@ -104,7 +104,7 @@ describe('Service Accounts API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(serviceAccountId).then(() => {
-                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}`;
+                const url = `${serviceUrl}/v1/serviceaccounts/${serviceAccountId}`;
                 httpSpy.should.have.been.calledWith('GET', url, undefined, authHeaders);
             });
         });
@@ -119,7 +119,7 @@ describe('Service Accounts API', () => {
             return api.update(serviceAccountId, {
                 name: serviceAccountName
             }).then(() => {
-                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}`;
+                const url = `${serviceUrl}/v1/serviceaccounts/${serviceAccountId}`;
                 httpSpy.should.have.been.calledWith('PUT', url, {
                     name: serviceAccountName
                 }, authHeaders);
@@ -134,7 +134,7 @@ describe('Service Accounts API', () => {
     describe('#delete', () => {
         it('should call http', () => {
             return api.delete(serviceAccountId).then(() => {
-                const url = `${serviceUrl}/serviceaccounts/${serviceAccountId}`;
+                const url = `${serviceUrl}/v1/serviceaccounts/${serviceAccountId}`;
                 httpSpy.should.have.been.calledWith('DELETE', url, undefined, authHeaders);
             });
         });

--- a/test/specs/api/stripe.spec.js
+++ b/test/specs/api/stripe.spec.js
@@ -5,7 +5,7 @@ import { testJwt } from '../../mocks/jwt';
 
 describe('Stripe API', () => {
     const serviceUrl = 'http://some-url.com';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
     let httpSpy;
@@ -13,7 +13,7 @@ describe('Stripe API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new StripeApi(serviceUrl, httpHeaders);
+        api = new StripeApi({serviceUrl, authHeaders});
     });
 
     afterEach(() => {
@@ -24,7 +24,7 @@ describe('Stripe API', () => {
         it('should call http', () => {
             return api.getAccount().then(() => {
                 const fullUrl = `${serviceUrl}/stripe/account`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });

--- a/test/specs/api/stripe.spec.js
+++ b/test/specs/api/stripe.spec.js
@@ -23,7 +23,7 @@ describe('Stripe API', () => {
     describe('#getAccount', () => {
         it('should call http', () => {
             return api.getAccount().then(() => {
-                const fullUrl = `${serviceUrl}/stripe/account`;
+                const fullUrl = `${serviceUrl}/v1/stripe/account`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });

--- a/test/specs/api/webhooks.spec.js
+++ b/test/specs/api/webhooks.spec.js
@@ -11,7 +11,7 @@ describe('Webhooks API', () => {
     const malformedTargetUrl = 'Malformed target url.';
     const noPropsMessage = 'Must provide props.';
     const noTargetMessage = 'Must provide a target.';
-    const httpHeaders = getAuthenticationHeaders({
+    const authHeaders = getAuthenticationHeaders({
         jwt: testJwt()
     });
     let httpSpy;
@@ -19,7 +19,7 @@ describe('Webhooks API', () => {
 
     beforeEach(() => {
         httpSpy = httpMock.mock();
-        api = new WebhooksApi(serviceUrl, httpHeaders);
+        api = new WebhooksApi({serviceUrl, authHeaders});
     });
 
     afterEach(() => {
@@ -67,7 +67,7 @@ describe('Webhooks API', () => {
         it('should call http', () => {
             return api.list().then(() => {
                 const fullUrl = `${serviceUrl}/webhooks`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -76,7 +76,7 @@ describe('Webhooks API', () => {
         it('should call http', () => {
             return api.get(webhookId).then(() => {
                 const fullUrl = `${serviceUrl}/webhooks/${webhookId}`;
-                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
     });
@@ -89,7 +89,7 @@ describe('Webhooks API', () => {
         it('should call http', () => {
             return api.create(props).then(() => {
                 const fullUrl = `${serviceUrl}/webhooks`;
-                httpSpy.should.have.been.calledWith('POST', fullUrl, props, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', fullUrl, props, authHeaders);
             });
         });
 
@@ -123,7 +123,7 @@ describe('Webhooks API', () => {
         it('should call http', () => {
             return api.update(webhookId, props).then(() => {
                 const fullUrl = `${serviceUrl}/webhooks/${webhookId}`;
-                httpSpy.should.have.been.calledWith('PUT', fullUrl, props, httpHeaders);
+                httpSpy.should.have.been.calledWith('PUT', fullUrl, props, authHeaders);
             });
         });
 
@@ -146,7 +146,7 @@ describe('Webhooks API', () => {
         it('should call http', () => {
             return api.delete(webhookId).then(() => {
                 const fullUrl = `${serviceUrl}/webhooks/${webhookId}`;
-                httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, authHeaders);
             });
         });
     });

--- a/test/specs/api/webhooks.spec.js
+++ b/test/specs/api/webhooks.spec.js
@@ -66,7 +66,7 @@ describe('Webhooks API', () => {
     describe('#list', () => {
         it('should call http', () => {
             return api.list().then(() => {
-                const fullUrl = `${serviceUrl}/webhooks`;
+                const fullUrl = `${serviceUrl}/v1/webhooks`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
@@ -75,7 +75,7 @@ describe('Webhooks API', () => {
     describe('#get', () => {
         it('should call http', () => {
             return api.get(webhookId).then(() => {
-                const fullUrl = `${serviceUrl}/webhooks/${webhookId}`;
+                const fullUrl = `${serviceUrl}/v1/webhooks/${webhookId}`;
                 httpSpy.should.have.been.calledWith('GET', fullUrl, undefined, authHeaders);
             });
         });
@@ -88,7 +88,7 @@ describe('Webhooks API', () => {
 
         it('should call http', () => {
             return api.create(props).then(() => {
-                const fullUrl = `${serviceUrl}/webhooks`;
+                const fullUrl = `${serviceUrl}/v1/webhooks`;
                 httpSpy.should.have.been.calledWith('POST', fullUrl, props, authHeaders);
             });
         });
@@ -122,7 +122,7 @@ describe('Webhooks API', () => {
 
         it('should call http', () => {
             return api.update(webhookId, props).then(() => {
-                const fullUrl = `${serviceUrl}/webhooks/${webhookId}`;
+                const fullUrl = `${serviceUrl}/v1/webhooks/${webhookId}`;
                 httpSpy.should.have.been.calledWith('PUT', fullUrl, props, authHeaders);
             });
         });
@@ -145,7 +145,7 @@ describe('Webhooks API', () => {
     describe('#delete', () => {
         it('should call http', () => {
             return api.delete(webhookId).then(() => {
-                const fullUrl = `${serviceUrl}/webhooks/${webhookId}`;
+                const fullUrl = `${serviceUrl}/v1/webhooks/${webhookId}`;
                 httpSpy.should.have.been.calledWith('DELETE', fullUrl, undefined, authHeaders);
             });
         });

--- a/test/specs/utils/smoochMethod.spec.js
+++ b/test/specs/utils/smoochMethod.spec.js
@@ -156,7 +156,10 @@ describe('Smooch Method', () => {
 
     describe('method requires appId', () => {
         beforeEach(() => {
-            testApi = new TestApi(serviceUrl, {}, {}, true);
+            testApi = new TestApi({
+                serviceUrl,
+                scope: 'account'
+            });
             expected = {
                 url: `${serviceUrl}/apps/${appId}/param1/${param1}`,
                 param1
@@ -189,7 +192,9 @@ describe('Smooch Method', () => {
 
     describe('appId resolved by credential scope', () => {
         beforeEach(() => {
-            testApi = new TestApi(serviceUrl, {}, {}, false);
+            testApi = new TestApi({
+                serviceUrl
+            });
             expected = {
                 url: `${serviceUrl}/param1/${param1}`,
                 param1
@@ -226,7 +231,9 @@ describe('Smooch Method', () => {
         const param3 = 'baz';
 
         beforeEach(() => {
-            testApi = new TestApi(serviceUrl, {}, {}, false);
+            testApi = new TestApi({
+                serviceUrl
+            });
             expected = {
                 url: `${serviceUrl}/param1/${param1}/param2/${param2}/param3/${param3}`,
                 param1,
@@ -253,7 +260,9 @@ describe('Smooch Method', () => {
     describe('method with single props arg', () => {
         let props;
         beforeEach(() => {
-            testApi = new TestApi(serviceUrl, {}, {}, false);
+            testApi = new TestApi({
+                serviceUrl
+            });
             props = {
                 a: 'foo',
                 b: 'bar'
@@ -275,7 +284,9 @@ describe('Smooch Method', () => {
 
     describe('method with no params', () => {
         beforeEach(() => {
-            testApi = new TestApi(serviceUrl, {}, {}, false);
+            testApi = new TestApi({
+                serviceUrl
+            });
             expected = `${serviceUrl}/foo`;
         });
 
@@ -299,7 +310,9 @@ describe('Smooch Method', () => {
     describe('method with optional params', () => {
         const param2 = 'bar';
         beforeEach(() => {
-            testApi = new TestApi(serviceUrl, {}, {}, false);
+            testApi = new TestApi({
+                serviceUrl
+            });
         });
 
         it('should accept full param list', () => {
@@ -333,12 +346,15 @@ describe('Smooch Method', () => {
         let expectedUrl;
         let body;
 
-        const httpHeaders = getAuthenticationHeaders({
+        const authHeaders = getAuthenticationHeaders({
             jwt: testJwt()
         });
 
         beforeEach(() => {
-            testApi = new TestApi(serviceUrl, httpHeaders, {}, false);
+            testApi = new TestApi({
+                serviceUrl,
+                authHeaders
+            });
             httpSpy = httpMock.mock();
             expectedUrl = `${serviceUrl}/param1/${param1}`;
             body = {
@@ -350,25 +366,25 @@ describe('Smooch Method', () => {
 
         it('should make a GET', () => {
             return testApi.getMethod(param1).then(() => {
-                httpSpy.should.have.been.calledWith('GET', expectedUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('GET', expectedUrl, undefined, authHeaders);
             });
         });
 
         it('should make a POST', () => {
             return testApi.postMethod(param1, body).then(() => {
-                httpSpy.should.have.been.calledWith('POST', expectedUrl, body, httpHeaders);
+                httpSpy.should.have.been.calledWith('POST', expectedUrl, body, authHeaders);
             });
         });
 
         it('should make a PUT', () => {
             return testApi.putMethod(param1, body).then(() => {
-                httpSpy.should.have.been.calledWith('PUT', expectedUrl, body, httpHeaders);
+                httpSpy.should.have.been.calledWith('PUT', expectedUrl, body, authHeaders);
             });
         });
 
         it('should make a DELETE', () => {
             return testApi.deleteMethod(param1).then(() => {
-                httpSpy.should.have.been.calledWith('DELETE', expectedUrl, undefined, httpHeaders);
+                httpSpy.should.have.been.calledWith('DELETE', expectedUrl, undefined, authHeaders);
             });
         });
     });

--- a/test/specs/utils/smoochMethod.spec.js
+++ b/test/specs/utils/smoochMethod.spec.js
@@ -5,7 +5,7 @@ import smoochMethod from '../../../src/utils/smoochMethod';
 import { getAuthenticationHeaders } from '../../../src/utils/auth';
 
 
-const serviceUrl = 'http://example.org/v1';
+const serviceUrl = 'http://example.org';
 const appId = 'appId';
 const param1 = 'foo';
 
@@ -161,7 +161,7 @@ describe('Smooch Method', () => {
                 scope: 'account'
             });
             expected = {
-                url: `${serviceUrl}/apps/${appId}/param1/${param1}`,
+                url: `${serviceUrl}/v1/apps/${appId}/param1/${param1}`,
                 param1
             };
         });
@@ -196,7 +196,7 @@ describe('Smooch Method', () => {
                 serviceUrl
             });
             expected = {
-                url: `${serviceUrl}/param1/${param1}`,
+                url: `${serviceUrl}/v1/param1/${param1}`,
                 param1
             };
         });
@@ -235,7 +235,7 @@ describe('Smooch Method', () => {
                 serviceUrl
             });
             expected = {
-                url: `${serviceUrl}/param1/${param1}/param2/${param2}/param3/${param3}`,
+                url: `${serviceUrl}/v1/param1/${param1}/param2/${param2}/param3/${param3}`,
                 param1,
                 param2,
                 param3
@@ -287,7 +287,7 @@ describe('Smooch Method', () => {
             testApi = new TestApi({
                 serviceUrl
             });
-            expected = `${serviceUrl}/foo`;
+            expected = `${serviceUrl}/v1/foo`;
         });
 
         it('should accept no params', () => {
@@ -356,7 +356,7 @@ describe('Smooch Method', () => {
                 authHeaders
             });
             httpSpy = httpMock.mock();
-            expectedUrl = `${serviceUrl}/param1/${param1}`;
+            expectedUrl = `${serviceUrl}/v1/param1/${param1}`;
             body = {
                 'foo': 'bar'
             };

--- a/test/specs/wrappers/node.spec.js
+++ b/test/specs/wrappers/node.spec.js
@@ -87,21 +87,6 @@ describe('Smooch', () => {
         }
     });
 
-    it('should accept custom headers', () => {
-        const authOptions = {
-            jwt: testJwt()
-        };
-
-        const customHeaders = {
-            myheader: '1234'
-        };
-
-        const smooch = new Smooch(Object.assign(authOptions, {
-            headers: customHeaders
-        }));
-        smooch.headers.should.deep.equal(customHeaders);
-    });
-
     describe('generating jwt', () => {
         const keyId = 'keyId';
         const secret = 'secret';

--- a/test/specs/wrappers/node.spec.js
+++ b/test/specs/wrappers/node.spec.js
@@ -121,4 +121,12 @@ describe('Smooch', () => {
             decodedToken.userId.should.equal(userId);
         });
     });
+
+    it('should accept custom serviceUrl', () => {
+        const smooch = new Smooch({
+            jwt: testJwt(),
+            serviceUrl: 'https://different.smooch.io'
+        });
+        smooch.serviceUrl.should.equal('https://different.smooch.io');
+    });
 });

--- a/test/specs/wrappers/node.spec.js
+++ b/test/specs/wrappers/node.spec.js
@@ -96,9 +96,9 @@ describe('Smooch', () => {
             myheader: '1234'
         };
 
-        var smooch = new Smooch(authOptions, {
+        const smooch = new Smooch(Object.assign(authOptions, {
             headers: customHeaders
-        });
+        }));
         smooch.headers.should.deep.equal(customHeaders);
     });
 


### PR DESCRIPTION
- Constructor auth and options are merged together into a single object
- Removed the `header` option
- Default base url is changed from `https://api.smooch.io/v1` to `https://api.smooch.io`, and `/v1` is no longer needed at the end of the `serviceUrl` option (which thus far has been undocumented)
- Api objects are refactored to accept objects instead of long param lists

Removing the custom headers option might be controversial, but it was never documented. It was originally only introduced for our own needs, and now I can't think of any use for it.

Moving the publicly documented `httpAgent` option is a breaking change, hence this will be published with a major version bump.